### PR TITLE
remove references to loo weights in vignettes

### DIFF
--- a/vignettes/binomial.Rmd
+++ b/vignettes/binomial.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Estimating Generalized Linear Models for Binary and Binomial Data with rstanarm"
 author: "Jonah Gabry and Ben Goodrich"
-date: "01/12/2016"
+date: "02/11/2016"
 output: 
   html_vignette: 
     toc: yes
@@ -292,10 +292,10 @@ by the `loo` function in the __loo__ package:
 compare(loo1, loo2)
 ```
 
-These results favor `fit2` over `fit1` by a wide margin. The estimated
+These results favor `fit2` over `fit1`, as the estimated
 difference in `elpd` (the expected log pointwise predictive density for a new
-dataset) is so much larger than its standard error that the model weight for
-`fit2` is 1. LOO penalizes models for adding additional predictors (this helps
+dataset) is so much larger than its standard error. 
+LOO penalizes models for adding additional predictors (this helps
 counter overfitting), but in this case `fit2` represents enough of an
 improvement over `fit1` that the penalty for including `arsenic` is negligible
 (as it should be if `arsenic` is an important predictor).

--- a/vignettes/continuous.Rmd
+++ b/vignettes/continuous.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Estimating Generalized Linear Models for Continuous Data with rstanarm"
 author: "Jonah Gabry and Ben Goodrich"
-date: "01/12/2016"
+date: "02/11/2016"
 output:
   html_vignette:
     toc: yes
@@ -215,9 +215,22 @@ loo4 <- loo(post4)
 compare(loo1, loo2, loo3, loo4)
 ```
 
-The `weights` column gives the estimated posterior probability that each model
-has the best expected out-of-sample predictive accuracy. In this case we can 
-see that the fourth model dominates.
+In this case the fourth model is preferred as it has the highest 
+expected log predicted density (`elpd`) or, equivalently, the lowest 
+value of the LOO Information Criterion (`looic`). The fourth model
+is preferred by a lot over the first model
+
+```{r, continuous-kidiq-loo-2}
+compare(loo1, loo4)
+```
+
+because the difference in `elpd` is so much larger than the standard error. 
+However, the preference of the fourth model over the others isn't as strong:
+
+```{r, continuous-kidiq-loo-3}
+compare(loo3, loo4)
+compare(loo2, loo4)
+```
 
 ## The posterior predictive distribution 
 

--- a/vignettes/count.Rmd
+++ b/vignettes/count.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Estimating Generalized Linear Models for Count Data with rstanarm"
 author: "Jonah Gabry and Ben Goodrich"
-date: "01/12/2016"
+date: "02/11/2016"
 output:
   html_vignette:
     toc: yes
@@ -222,7 +222,7 @@ function takes care of this for us, but `yrep` can be used directly to carry out
 other posterior predictive checks that aren't automated by `pp_check`. 
 
 When we comparing the models using the __loo__ package we also see a clear
-preference for the negative binomial model:
+preference for the negative binomial model
 
 ```{r, count-roaches-loo}
 loo1 <- loo(stan_glm1)
@@ -230,8 +230,8 @@ loo2 <- loo(stan_glm2)
 compare(loo1, loo2)
 ```
 
-The weight of 1 assigned to the negative binomial is not surprising given 
-the better fit we've already observed from the posterior predictive checks.
+which is not surprising given the better fit we've already observed from the
+posterior predictive checks.
 
 
 # References

--- a/vignettes/pooling.Rmd
+++ b/vignettes/pooling.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Hierarchical Partial Pooling for Repeated Binary Trials"
 author: "Bob Carpenter, Jonah Gabry and Ben Goodrich"
-date: "02/08/2016"
+date: "02/11/2016"
 output: 
   html_vignette:
     toc: yes
@@ -778,10 +778,7 @@ predictive densities found in the previous subsection.
 Nevertheless, the relative ranking of the models is essentially
 the same with the pooled and partially pooled models being
 virtually indistinguishable but much better than the no pooling
-model. If we wanted to average some function of the posterior
-predictions (see the next section), we could use the weights in
-the last column, which would effectively average the pooling and
-partially pooling models with equal weight.
+model.
 
 ## Predicting New Observations
 

--- a/vignettes/rstanarm.Rmd
+++ b/vignettes/rstanarm.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "How to Use the rstanarm Package"
 author: "Jonah Gabry and Ben Goodrich"
-date: "02/08/2016"
+date: "02/11/2016"
 output: 
   html_vignette: 
     toc: yes


### PR DESCRIPTION
@bgoodri Aki wants to remove the weights from the `loo::compare()` output until we’ve done more work on those. This PR just removes references to the weights from the rstanarm vignettes