### PR TITLE
Bugfix issue109 posterior predict with offset

### DIFF
--- a/R/loo.R
+++ b/R/loo.R
@@ -369,13 +369,13 @@ ll_fun <- function(x) {
 
 # arguments for loo.function ----------------------------------------------
 # returns 'args' argument for loo.function() and waic.function()
-ll_args <- function(object, newdata = NULL) {
+ll_args <- function(object, newdata = NULL, offset = NULL) {
   validate_stanreg_object(object)
   f <- family(object)
   draws <- nlist(f)
   has_newdata <- !is.null(newdata)
   if (has_newdata) {
-    ppdat <- pp_data(object, as.data.frame(newdata))
+    ppdat <- pp_data(object, as.data.frame(newdata), offset = offset)
     tmp <- pp_eta(object, ppdat)
     eta <- tmp$eta
     stanmat <- tmp$stanmat

--- a/R/posterior_linpred.R
+++ b/R/posterior_linpred.R
@@ -30,7 +30,7 @@
 #' @param transform Should the linear predictor be transformed using the
 #'   inverse-link function? The default is \code{FALSE}, in which case the 
 #'   untransformed linear predictor is returned.
-#' @param newdata,re.form Same as for \code{\link{posterior_predict}}.
+#' @param newdata,re.form,offset Same as for \code{\link{posterior_predict}}.
 #' @param ... Currently unused.
 #' 
 #' @return A \code{draws} by \code{nrow(newdata)} matrix of simulations from the
@@ -51,7 +51,7 @@
 #' probs2 <- posterior_linpred(example_model, transform = TRUE, re.form = NA)
 #' 
 posterior_linpred <- function(object, transform = FALSE, newdata = NULL, 
-                              re.form = NULL, ...) {
+                              re.form = NULL, offset = NULL, ...) {
   validate_stanreg_object(object)
   if (used.optimizing(object))
     STOP_not_optimizing("posterior_linpred")
@@ -63,7 +63,7 @@ posterior_linpred <- function(object, transform = FALSE, newdata = NULL,
     if (any(is.na(newdata))) 
       stop("Currently NAs are not allowed in 'newdata'.")
   }
-  dat <- pp_data(object, newdata = newdata, re.form = re.form, ...)
+  dat <- pp_data(object, newdata = newdata, re.form = re.form, offset = offset, ...)
   eta <- pp_eta(object, data = dat, draws = NULL)[["eta"]]
   if (!transform)
     return(eta)

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -55,6 +55,9 @@
 #'   by a call to \code{\link{match.fun}} and so can be specified as a function
 #'   object, a string naming a function, etc.
 #' @param seed An optional \code{\link[=set.seed]{seed}} to use.
+#' @param offset A vector of offsets. Only required if \code{newdata} is
+#'   specified and an \code{offset} argument was specified when fitting the
+#'   model.
 #' @param ... Currently unused.
 #' 
 #' @return A \code{draws} by \code{nrow(newdata)} matrix of simulations
@@ -123,7 +126,8 @@
 #' }
 #' 
 posterior_predict <- function(object, newdata = NULL, draws = NULL, 
-                              re.form = NULL, fun = NULL, seed = NULL, ...) {
+                              re.form = NULL, fun = NULL, seed = NULL, 
+                              offset = NULL, ...) {
   validate_stanreg_object(object)
   if (used.optimizing(object))
     STOP_not_optimizing("posterior_predict")
@@ -139,7 +143,12 @@ posterior_predict <- function(object, newdata = NULL, draws = NULL,
     if (any(is.na(newdata))) 
       stop("Currently NAs are not allowed in 'newdata'.")
   }
-  dat <- pp_data(object, newdata, re.form, ...)
+  dat <-
+    pp_data(object,
+            newdata = newdata,
+            re.form = re.form,
+            offset = offset,
+            ...)
   if (is_scobit(object)) {
     data <- pp_eta(object, dat, NULL)
     if (!is.null(draws)) {

--- a/R/pp_data.R
+++ b/R/pp_data.R
@@ -156,6 +156,10 @@ pp_data <-
 
 
 # handle offsets ----------------------------------------------------------
+null_or_zero <- function(x) {
+  isTRUE(is.null(x) || all(x == 0))
+}
+
 .pp_data_offset <- function(object, newdata = NULL, offset = NULL) {
   if (is.null(newdata)) {
     # get offset from model object (should be null if no offset)
@@ -168,8 +172,8 @@ pp_data <-
       # if newdata specified but not offset then confirm that model wasn't fit
       # with an offset (warning, not error)
       if (!is.null(object$call$offset) || 
-          !is.null(object$offset) || 
-          !is.null(model.offset(model.frame(object)))) {
+          !null_or_zero(object$offset) || 
+          !null_or_zero(model.offset(model.frame(object)))) {
         warning(
           "'offset' argument is NULL but it looks like you estimated ", 
           "the model using an offset term.", 

--- a/R/pp_data.R
+++ b/R/pp_data.R
@@ -169,11 +169,13 @@ pp_data <-
       # with an offset (warning, not error)
       if (!is.null(object$call$offset) || 
           !is.null(object$offset) || 
-          !is.null(model.offset(model.frame(object))))
+          !is.null(model.offset(model.frame(object)))) {
         warning(
           "'offset' argument is NULL but it looks like you estimated ", 
-          "the model using an offset term."
+          "the model using an offset term.", 
+          call. = FALSE
         )
+      }
       offset <- rep(0, nrow(newdata))
     }
   }

--- a/R/stanreg-methods.R
+++ b/R/stanreg-methods.R
@@ -129,7 +129,11 @@ log_lik <- function(object, ...) UseMethod("log_lik")
 #' @param newdata For \code{log_lik}, an optional data frame of new data (e.g. 
 #'   holdout data) to use when evaluating the log-likelihood. See the 
 #'   description of \code{newdata} for \code{\link{posterior_predict}}.
-log_lik.stanreg <- function(object, newdata = NULL, ...) {
+#' @param offset For \code{log_lik}, a vector of offsets. Only required if
+#'   \code{newdata} is specified and an \code{offset} was specified when fitting
+#'   the model.
+#' 
+log_lik.stanreg <- function(object, newdata = NULL, offset = NULL, ...) {
   if (!used.sampling(object)) 
     STOP_sampling_only("Pointwise log-likelihood matrix")
   if (!is.null(newdata)) {
@@ -139,7 +143,7 @@ log_lik.stanreg <- function(object, newdata = NULL, ...) {
     newdata <- as.data.frame(newdata)
   }
   fun <- ll_fun(object)
-  args <- ll_args(object, newdata)
+  args <- ll_args(object, newdata = newdata, offset = offset)
   sapply(seq_len(args$N), function(i) {
     as.vector(fun(i = i, data = args$data[i, , drop = FALSE], 
                   draws = args$draws))

--- a/tests/testthat/test_loo.R
+++ b/tests/testthat/test_loo.R
@@ -60,7 +60,7 @@ test_that("loo & waic throw error for non mcmc models", {
 })
 
 test_that("loo errors if model has weights", {
-  fit <- stan_glm(mpg ~ wt, data = mtcars, weights = rep(1, nrow(mtcars)), 
+  fit <- stan_glm(mpg ~ wt, data = mtcars, weights = rep_len(c(1,2), nrow(mtcars)), 
                   seed = SEED, refresh = REFRESH, iter = 50)
   expect_error(loo(fit), "not supported")
   expect_error(loo(fit), "'kfold'")


### PR DESCRIPTION
@bgoodri can you take a look at this quickly before we merge? 

closes #109 

* Adds `offset` argument to `posterior_predict`, `posterior_linpred`, and `log_lik`

* `offset` argument is __required__ if `newdata` is specified and model was fit using an offset
