### PR TITLE
Validate glm outcome support

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -302,7 +302,7 @@ check_constant_vars <- function(mf) {
   lu <- function(x) length(unique(x))
   nocheck <- c("(weights)", "(offset)", "(Intercept)")
   sel <- !colnames(mf1) %in% nocheck
-  is_constant <- apply(mf1[, sel, drop = FALSE], 2, lu) == 1
+  is_constant <- apply(mf1[, sel, drop=FALSE], 2, lu) == 1
   if (any(is_constant)) 
     stop("Constant variable(s) found: ", 
          paste(names(is_constant)[is_constant], collapse = ", "), 

--- a/R/misc.R
+++ b/R/misc.R
@@ -297,7 +297,7 @@ validate_glm_formula <- function(f) {
 #   is thrown.
 check_constant_vars <- function(mf) {
   # don't check if columns are constant for binomial
-  mf1 <- if (NCOL(mf[, 1]) == 2) mf[, -1] else mf
+  mf1 <- if (NCOL(mf[, 1]) == 2) mf[, -1, drop=FALSE] else mf
   
   lu <- function(x) length(unique(x))
   nocheck <- c("(weights)", "(offset)", "(Intercept)")

--- a/R/stan_glm.fit.R
+++ b/R/stan_glm.fit.R
@@ -75,20 +75,11 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
     stop("To specify 'y' as proportion of successes and 'weights' as ",
          "number of trials please use stan_glm rather than calling ",
          "stan_glm.fit directly.")
-  if (is.binomial(family$family)) {
-    if (NCOL(y) == 1L) {
-      if (is.numeric(y) || is.logical(y)) 
-        y <- as.integer(y)
-      if (is.factor(y)) 
-        y <- fac2bin(y)
-      if (!all(y %in% c(0L, 1L))) 
-        stop("y values must be 0 or 1 for bernoulli regression.")
-    } else {
-      if (!isTRUE(NCOL(y) == 2L))
-        stop("y should either be a vector or a matrix 1 or 2 columns.")
-      trials <- as.integer(y[, 1L] + y[, 2L])
-      y <- as.integer(y[, 1L])
-    }
+  
+  y <- validate_glm_outcome_support(y, family)
+  if (is.binomial(family$family) && NCOL(y) == 2L) {
+    trials <- as.integer(y[, 1L] + y[, 2L])
+    y <- as.integer(y[, 1L])
   }
 
   # useless assignments to pass R CMD check
@@ -520,6 +511,74 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
     return(structure(stanfit, prior.info = prior_info))
   }
 }
+
+
+
+# internal ----------------------------------------------------------------
+
+# Verify that outcome values match support implied by family object
+#
+# @param y outcome variable
+# @param family family object
+# @return y (possibly slightly modified) unless an error is thrown
+#
+validate_glm_outcome_support <- function(y, family) {
+  .is_count <- function(x) {
+    all(x >= 0) && all(abs(x - round(x)) < .Machine$double.eps^0.5)
+  }
+  
+  fam <- family$family
+  
+  if (!is.binomial(fam)) {
+    # make sure y has ok dimensions (matrix only allowed for binomial models)
+    if (length(dim(y)) > 1) {
+      if (NCOL(y) == 1) {
+        y <- y[, 1]
+      } else {
+        stop("Except for binomial models the outcome variable ",
+             "should not have multiple columns.", 
+             call. = FALSE)
+      }
+    }
+    
+    # check that values match support for non-binomial models
+    if (is.gaussian(fam)) {
+      return(y)
+    } else if (is.gamma(fam) && any(y <= 0)) {
+      stop("All outcome values must be positive for gamma models.", 
+           call. = FALSE)
+    } else if (is.ig(fam) && any(y <= 0)) {
+      stop("All outcome values must be positive for inverse-Gaussian models.", 
+           call. = FALSE)
+    } else if (is.poisson(fam) && !.is_count(y)) {
+      stop("All outcome values must be counts for Poisson models",
+           call. = FALSE)
+    } else if (is.nb(fam) && !.is_count(y)) {
+      stop("All outcome values must be counts for negative binomial models",
+           call. = FALSE)
+    }
+  } else { # binomial models
+    if (NCOL(y) == 1L) {
+      if (is.numeric(y) || is.logical(y)) 
+        y <- as.integer(y)
+      if (is.factor(y)) 
+        y <- fac2bin(y)
+      if (!all(y %in% c(0L, 1L))) 
+        stop("All outcome values must be 0 or 1 for Bernoulli models.", 
+             call. = FALSE)
+    } else if (isTRUE(NCOL(y) == 2L) && !.is_count(y)) {
+      stop("All outcome values must be counts for binomial models.",
+           call. = FALSE)
+    } else {
+      stop("For binomial models the outcome should be a vector or ",
+           "a matrix with 2 columns.", 
+           call. = FALSE)
+    }
+  }
+  
+  return(y)
+}
+
 
 
 # Add extra level _NEW_ to each group

--- a/R/stan_glm.fit.R
+++ b/R/stan_glm.fit.R
@@ -566,9 +566,10 @@ validate_glm_outcome_support <- function(y, family) {
       if (!all(y %in% c(0L, 1L))) 
         stop("All outcome values must be 0 or 1 for Bernoulli models.", 
              call. = FALSE)
-    } else if (isTRUE(NCOL(y) == 2L) && !.is_count(y)) {
-      stop("All outcome values must be counts for binomial models.",
-           call. = FALSE)
+    } else if (isTRUE(NCOL(y) == 2L)) {
+      if (!.is_count(y))
+        stop("All outcome values must be counts for binomial models.",
+             call. = FALSE)
     } else {
       stop("For binomial models the outcome should be a vector or ",
            "a matrix with 2 columns.", 

--- a/R/stan_glm.fit.R
+++ b/R/stan_glm.fit.R
@@ -312,6 +312,8 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
 
   # call stan() to draw from posterior distribution
   if (is_continuous) {
+    standata$ub_y <- Inf
+    standata$lb_y <- if (is_gaussian) -Inf else 0
     standata$prior_scale_for_dispersion <- prior_scale_for_dispersion %ORifINF% 0
     standata$prior_df_for_dispersion <- c(prior_df_for_dispersion)
     standata$prior_mean_for_dispersion <- c(prior_mean_for_dispersion)

--- a/exec/continuous.stan
+++ b/exec/continuous.stan
@@ -25,7 +25,9 @@ functions {
 }
 data {
   #include "NKX.stan"      // declares N, K, X, xbar, dense_X, nnz_x, w_x, v_x, u_x
-  vector[N] y; // continuous outcome
+  real lb_y; // lower bound on y
+  real<lower=lb_y> ub_y; // upper bound on y
+  vector<lower=lb_y, upper=ub_y>[N] y; // continuous outcome
   #include "data_glm.stan" // declares prior_PD, has_intercept, family, link, prior_dist, prior_dist_for_intercept
   #include "weights_offset.stan"  // declares has_weights, weights, has_offset, offset
   // declares prior_{mean, scale, df}, prior_{mean, scale, df}_for_intercept, prior_scale_for dispersion

--- a/tests/testthat/test_stan_glm.R
+++ b/tests/testthat/test_stan_glm.R
@@ -58,7 +58,7 @@ test_that("stan_glm throws appropriate errors, warnings, and messages", {
                regexp = "'QR' and 'sparse' cannot both be TRUE")
   
   # message: recommend QR if using meanfield vb
-  expect_message(stan_glm(f, family = "poisson", algorithm = "meanfield", seed = SEED), 
+  expect_message(capture.output(stan_glm(f, family = "poisson", algorithm = "meanfield", seed = SEED)), 
                  regexp = "Setting 'QR' to TRUE can often be helpful")
   
   # require intercept for certain family and link combinations
@@ -197,9 +197,11 @@ test_that("stan_glm returns expected result for bernoulli", {
     theta <- fam$linkinv(-1 + x %*% b)
     y <- rbinom(length(theta), size = 1, prob = theta)
   
-    fit <- stan_glm(y ~ x, family = fam, seed  = SEED, QR = TRUE,
+    capture.output(
+      fit <- stan_glm(y ~ x, family = fam, seed  = SEED, QR = TRUE,
                     prior = NULL, prior_intercept = NULL,
                     tol_rel_obj = .Machine$double.eps, algorithm = "optimizing")
+    )
     expect_stanreg(fit)
     
     val <- coef(fit)
@@ -227,9 +229,11 @@ test_that("stan_glm returns expected result for binomial example", {
     else b <- c(0, 0.5, 0.1, -1.0)
     yes <- rbinom(N, size = trials, prob = fam$linkinv(X %*% b))
     y <- cbind(yes, trials - yes)
-    fit <- stan_glm(y ~ X[,-1], family = fam, seed  = SEED, QR = TRUE,
+    capture.output(
+      fit <- stan_glm(y ~ X[,-1], family = fam, seed  = SEED, QR = TRUE,
                     prior = NULL, prior_intercept = NULL,
                     tol_rel_obj = .Machine$double.eps, algorithm = "optimizing")
+    )
     expect_stanreg(fit)
     
     val <- coef(fit)
@@ -238,9 +242,11 @@ test_that("stan_glm returns expected result for binomial example", {
     else expect_equal(val[-1], ans[-1], 0.008, info = links[i])
 
     prop <- yes / trials
-    fit2 <- stan_glm(prop ~ X[,-1], weights = trials, family = fam, seed  = SEED,
+    capture.output(
+      fit2 <- stan_glm(prop ~ X[,-1], weights = trials, family = fam, seed  = SEED,
                      prior = NULL, prior_intercept = NULL,
                      tol_rel_obj = .Machine$double.eps, algorithm = "optimizing")
+    )
     expect_stanreg(fit2)
     
     val2 <- coef(fit2)


### PR DESCRIPTION
* verify outcome values match support implied by family object in `stan_glm.fit`
* add lower and upper bounds for `y` in `continuous.stan`

closes #144 