### PR TITLE
Dispersion to nuisance

### DIFF
--- a/R/as.matrix.stanreg.R
+++ b/R/as.matrix.stanreg.R
@@ -81,9 +81,9 @@ as.matrix.stanreg <- function(x, ..., pars = NULL, regex_pars = NULL) {
     if (is.null(mat)) 
       STOP_no_draws()
     if (!user_pars) {
-      dispersion <- c("sigma", "scale", "shape", "lambda", "reciprocal_dispersion")
+      nuisance <- c("sigma", "scale", "shape", "lambda", "reciprocal_dispersion")
       pars <- c(names(coef(x)), # return with coefficients first
-                dispersion[which(dispersion %in% colnames(mat))])
+                nuisance[which(nuisance %in% colnames(mat))])
     }
   } else { # used mcmc or vb
     mat <- as.matrix(x$stanfit)

--- a/R/as.matrix.stanreg.R
+++ b/R/as.matrix.stanreg.R
@@ -81,7 +81,7 @@ as.matrix.stanreg <- function(x, ..., pars = NULL, regex_pars = NULL) {
     if (is.null(mat)) 
       STOP_no_draws()
     if (!user_pars) {
-      dispersion <- c("sigma", "scale", "shape", "lambda", "overdispersion")
+      dispersion <- c("sigma", "scale", "shape", "lambda", "reciprocal_dispersion")
       pars <- c(names(coef(x)), # return with coefficients first
                 dispersion[which(dispersion %in% colnames(mat))])
     }

--- a/R/log_lik.R
+++ b/R/log_lik.R
@@ -155,7 +155,7 @@ ll_args <- function(object, newdata = NULL, offset = NULL,
     if (is.ig(fname)) 
       draws$lambda <- stanmat[, "lambda"]
     if (is.nb(fname)) 
-      draws$size <- stanmat[,"overdispersion"]
+      draws$size <- stanmat[,"reciprocal_dispersion"]
     
   } else {
     stopifnot(is(object, "polr"))

--- a/R/neg_binomial_2.R
+++ b/R/neg_binomial_2.R
@@ -20,9 +20,10 @@
 #' Specifies the information required to fit a Negative Binomial GLM in a 
 #' similar way to \code{\link[MASS]{negative.binomial}}. However, here the 
 #' overdispersion parameter \code{theta} is not specified by the user and always
-#' estimated. A call to this function can be passed to the \code{family}
-#' argument of \code{\link{stan_glm}} or \code{\link{stan_glmer}} to estimate a
-#' Negative Binomial model. Alternatively, the \code{\link{stan_glm.nb}} and 
+#' estimated (really the reciprocal of the dispersion parameter is estimated). A
+#' call to this function can be passed to the \code{family} argument of
+#' \code{\link{stan_glm}} or \code{\link{stan_glmer}} to estimate a Negative
+#' Binomial model. Alternatively, the \code{\link{stan_glm.nb}} and 
 #' \code{\link{stan_glmer.nb}} wrapper functions may be used, which call 
 #' \code{neg_binomial_2} internally.
 #' 

--- a/R/neg_binomial_2.R
+++ b/R/neg_binomial_2.R
@@ -20,10 +20,10 @@
 #' Specifies the information required to fit a Negative Binomial GLM in a 
 #' similar way to \code{\link[MASS]{negative.binomial}}. However, here the 
 #' overdispersion parameter \code{theta} is not specified by the user and always
-#' estimated (really the reciprocal of the dispersion parameter is estimated). A
-#' call to this function can be passed to the \code{family} argument of
-#' \code{\link{stan_glm}} or \code{\link{stan_glmer}} to estimate a Negative
-#' Binomial model. Alternatively, the \code{\link{stan_glm.nb}} and 
+#' estimated (really the \emph{reciprocal} of the dispersion parameter is
+#' estimated). A call to this function can be passed to the \code{family}
+#' argument of \code{\link{stan_glm}} or \code{\link{stan_glmer}} to estimate a
+#' Negative Binomial model. Alternatively, the \code{\link{stan_glm.nb}} and 
 #' \code{\link{stan_glmer.nb}} wrapper functions may be used, which call 
 #' \code{neg_binomial_2} internally.
 #' 

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -275,7 +275,7 @@ pp_args <- function(object, data) {
   } else if (is.ig(famname)) {
     args$lambda <- stanmat[, "lambda"]
   } else if (is.nb(famname)) {
-    args$size <- stanmat[, "overdispersion"]
+    args$size <- stanmat[, "reciprocal_dispersion"]
   }
   args
 }

--- a/R/pp_validate.R
+++ b/R/pp_validate.R
@@ -105,7 +105,7 @@ pp_validate <- function(object, nreps = 20, seed = 12345, ...) {
   if (nreps < 2)
     stop("'nreps' must be at least 2.")
 
-  dims <- object$stanfit@par_dims[c("alpha", "beta", "b", "dispersion", "cutpoints", "theta_L")]
+  dims <- object$stanfit@par_dims[c("alpha", "beta", "b", "nuisance", "cutpoints", "theta_L")]
   dims <- dims[!sapply(dims, is.null)]
   dims <- sapply(dims, prod)
   dims <- dims[dims > 0]

--- a/R/print-and-summary.R
+++ b/R/print-and-summary.R
@@ -121,7 +121,7 @@ print.stanreg <- function(x, digits = 1, ...) {
     } else if (is.ig(famname)) {
       nms <- c(nms, "lambda")
     } else if (is.nb(famname)) {
-      nms <- c(nms, "overdispersion")
+      nms <- c(nms, "reciprocal_dispersion")
     }
     nms <- c(nms, grep("^mean_PPD", rownames(x$stan_summary), value = TRUE))
     estimates <- x$stan_summary[nms,1:2]
@@ -245,7 +245,7 @@ summary.stanreg <- function(object, pars = NULL, regex_pars = NULL,
       if (is.gaussian(famname)) 
         mark <- c(mark, "sigma")
       if (is.nb(famname)) 
-        mark <- c(mark, "overdispersion") 
+        mark <- c(mark, "reciprocal_dispersion") 
     } else {
       mark <- NA
       if ("alpha" %in% pars) 

--- a/R/prior_summary.R
+++ b/R/prior_summary.R
@@ -138,11 +138,11 @@ print.prior_summary.stanreg <- function(x, digits, ...) {
       txt = paste0("\nCoefficients", if (QR) " (in Q-space)"), 
       formatters = formatters
     )
-  if (!is.null(x[["prior_dispersion"]])) {
-    dispersion_name <- x[["prior_dispersion"]][["dispersion_name"]]
+  if (!is.null(x[["prior_nuisance"]])) {
+    nuisance_name <- x[["prior_nuisance"]][["nuisance_name"]]
     .print_scalar_prior(
-      x[["prior_dispersion"]], 
-      txt = paste0("\n", dispersion_name), 
+      x[["prior_nuisance"]], 
+      txt = paste0("\n", nuisance_name), 
       formatters
     )
   }

--- a/R/priors.R
+++ b/R/priors.R
@@ -277,7 +277,7 @@
 #'                            chains = 1, seed = 12345, iter = 500, # for speed only
 #'                            prior = student_t(df = 4, 0, 2.5), 
 #'                            prior_intercept = cauchy(0,10), 
-#'                            prior_dispersion = exponential(1/2))
+#'                            prior_nuisance = exponential(1/2))
 #' plot(prior_pred_fit, "hist")
 #' 
 #' \donttest{

--- a/R/rstanarm-deprecated.R
+++ b/R/rstanarm-deprecated.R
@@ -17,9 +17,9 @@ NULL
 #'   \describe{
 #'   \item{\code{prior_scale_for_dispersion}}{
 #'    Instead of using the \code{prior_scale_for_dispersion} argument to 
-#'    \code{prior_options}, priors for dispersion parameters can now be 
+#'    \code{prior_options}, priors for these parameters can now be 
 #'    specified directly when calling \code{\link{stan_glm}} (or
-#'    \code{\link{stan_glmer}}, etc.) using the new \code{prior_dispersion}
+#'    \code{\link{stan_glmer}}, etc.) using the new \code{prior_nuisance}
 #'    argument.
 #'   }
 #'   \item{\code{scaled}}{
@@ -39,8 +39,8 @@ prior_options <- function(prior_scale_for_dispersion = 5,
                           scaled = TRUE) {
   warning(
     "'prior_options' is deprecated and will be removed in a future release.",
-    "\n* Priors for dispersion parameters should now be set using",
-    " the new 'prior_dispersion' argument when calling ",
+    "\n* Priors for nuisance parameters should now be set using",
+    " the new 'prior_nuisance' argument when calling ",
     "'stan_glm', 'stan_glmer', etc.",
     "\n* Instead of setting 'prior_options(scaled=FALSE)',", 
     " internal rescaling is now toggled using the", 
@@ -60,7 +60,7 @@ prior_options <- function(prior_scale_for_dispersion = 5,
 .support_deprecated_prior_options <- 
   function(prior, 
            prior_intercept, 
-           prior_dispersion, 
+           prior_nuisance, 
            prior_ops) {
     if (!isTRUE(attr(prior_ops, "from_prior_options")))
       stop(
@@ -74,14 +74,14 @@ prior_options <- function(prior_scale_for_dispersion = 5,
     po_disp_scale <- prior_ops[["prior_scale_for_dispersion"]]
     po_scaled <- prior_ops[["scaled"]]
     
-    if (!is.null(prior_dispersion) && !is.null(po_disp_scale)) {
-      if (po_disp_scale != prior_dispersion[["scale"]]) {
+    if (!is.null(prior_nuisance) && !is.null(po_disp_scale)) {
+      if (po_disp_scale != prior_nuisance[["scale"]]) {
         warning(
-          "Setting prior scale for dispersion to value specified in ",
-          "'prior_options' rather than value specified in 'prior_dispersion'.",
+          "Setting prior scale for nuisance to value specified in ",
+          "'prior_options' rather than value specified in 'prior_nuisance'.",
           call. = FALSE
         )
-        prior_dispersion[["scale"]] <- po_disp_scale
+        prior_nuisance[["scale"]] <- po_disp_scale
       }
     }
     if (!is.null(po_scaled) && identical(po_scaled, FALSE)) {
@@ -91,6 +91,6 @@ prior_options <- function(prior_scale_for_dispersion = 5,
         prior_intercept$autoscale <- FALSE
     }
     
-    nlist(prior, prior_intercept, prior_dispersion)
+    nlist(prior, prior_intercept, prior_nuisance)
   }
 

--- a/R/stan_gamm4.R
+++ b/R/stan_gamm4.R
@@ -113,7 +113,7 @@ stan_gamm4 <- function(formula, random = NULL, family = gaussian(), data = list(
                        weights = NULL, subset = NULL, na.action, knots = NULL, 
                        drop.unused.levels = TRUE, ..., 
                        prior = normal(), prior_intercept = normal(),
-                       prior_dispersion = cauchy(0, 5),
+                       prior_nuisance = cauchy(0, 5),
                        prior_covariance = decov(), prior_PD = FALSE, 
                        algorithm = c("sampling", "meanfield", "fullrank"), 
                        adapt_delta = NULL, QR = FALSE, sparse = FALSE) {
@@ -134,8 +134,8 @@ stan_gamm4 <- function(formula, random = NULL, family = gaussian(), data = list(
     prior <- list()
   if (is.null(prior_intercept)) 
     prior_intercept <- list()
-  if (is.null(prior_dispersion)) 
-    prior_dispersion <- list()
+  if (is.null(prior_nuisance)) 
+    prior_nuisance <- list()
 
   group <- glmod$reTrms
   group$decov <- prior_covariance
@@ -144,7 +144,7 @@ stan_gamm4 <- function(formula, random = NULL, family = gaussian(), data = list(
   stanfit <- stan_glm.fit(x = X, y = y, weights = weights,
                           offset = offset, family = family,
                           prior = prior, prior_intercept = prior_intercept,
-                          prior_dispersion = prior_dispersion, prior_PD = prior_PD, 
+                          prior_nuisance = prior_nuisance, prior_PD = prior_PD, 
                           algorithm = algorithm, adapt_delta = adapt_delta,
                           group = group, QR = QR, ...)
 

--- a/R/stan_glm.R
+++ b/R/stan_glm.R
@@ -57,7 +57,7 @@
 #'   
 #'   The \code{stan_glm.nb} function, which takes the extra argument 
 #'   \code{link}, is a simple wrapper for \code{stan_glm} with \code{family = 
-#'   \link{neg_binomial_2}(link)}. The \code{prior_dispersion} argument can be 
+#'   \link{neg_binomial_2}(link)}. The \code{prior_nuisance} argument can be 
 #'   used to set a prior on the overdispersion parameter.
 #'   
 #' @seealso The various vignettes for \code{stan_glm}.
@@ -115,7 +115,7 @@
 #'   Days ~ Sex/(Age + Eth*Lrn), 
 #'   data = MASS::quine, 
 #'   QR = TRUE, 
-#'   prior_dispersion = exponential(1/2),
+#'   prior_nuisance = exponential(1/2),
 #'   # could also use stan_glm.nb and drop the family argument
 #'   family = neg_binomial_2(link = "log")
 #' )
@@ -133,7 +133,7 @@ stan_glm <- function(formula, family = gaussian(), data, weights, subset,
                     na.action = NULL, offset = NULL, model = TRUE, 
                     x = FALSE, y = TRUE, contrasts = NULL, ..., 
                     prior = normal(), prior_intercept = normal(),
-                    prior_dispersion = cauchy(0, 5),
+                    prior_nuisance = cauchy(0, 5),
                     prior_PD = FALSE, 
                     algorithm = c("sampling", "optimizing", 
                                   "meanfield", "fullrank"),
@@ -170,7 +170,7 @@ stan_glm <- function(formula, family = gaussian(), data, weights, subset,
                           offset = offset, family = family,
                           prior = prior, 
                           prior_intercept = prior_intercept,
-                          prior_dispersion = prior_dispersion,
+                          prior_nuisance = prior_nuisance,
                           prior_PD = prior_PD, 
                           algorithm = algorithm, adapt_delta = adapt_delta, 
                           QR = QR, sparse = sparse, ...)
@@ -209,7 +209,7 @@ stan_glm.nb <- function(formula,
                         ...,
                         prior = normal(),
                         prior_intercept = normal(),
-                        prior_dispersion = cauchy(0, 5),
+                        prior_nuisance = cauchy(0, 5),
                         prior_PD = FALSE,
                         algorithm = c("sampling", "optimizing", 
                                       "meanfield", "fullrank"),

--- a/R/stan_glm.R
+++ b/R/stan_glm.R
@@ -56,9 +56,8 @@
 #'   but it is also possible to call the latter directly.
 #'   
 #'   The \code{stan_glm.nb} function, which takes the extra argument 
-#'   \code{link}, is a simple wrapper for \code{stan_glm} with \code{family = 
-#'   \link{neg_binomial_2}(link)}. The \code{prior_nuisance} argument can be 
-#'   used to set a prior on the overdispersion parameter.
+#'   \code{link}, is a wrapper for \code{stan_glm} with \code{family = 
+#'   \link{neg_binomial_2}(link)}.
 #'   
 #' @seealso The various vignettes for \code{stan_glm}.
 #' 
@@ -111,22 +110,17 @@
 #' fit5 <- update(fit4, formula = lot2 ~ log_u)
 #' 
 #' ### Negative binomial regression
-#' fit6 <- stan_glm(
-#'   Days ~ Sex/(Age + Eth*Lrn), 
-#'   data = MASS::quine, 
-#'   QR = TRUE, 
-#'   prior_nuisance = exponential(1/2),
-#'   # could also use stan_glm.nb and drop the family argument
-#'   family = neg_binomial_2(link = "log")
-#' )
+#' fit6 <- stan_glm.nb(Days ~ Sex/(Age + Eth*Lrn), data = MASS::quine, 
+#'                     link = "log", prior_nuisance = exponential(1/2),
+#'                     QR = TRUE)
 #' 
 #' bayesplot::color_scheme_set("brightblue")
 #' plot(fit6)
 #' pp_check(fit6, plotfun = "hist", nreps = 5)
 #' 
-#' # 80% interval of estimated overdispersion parameter
-#' posterior_interval(fit6, pars = "overdispersion", prob = 0.8)
-#' plot(fit6, "areas", pars = "overdispersion", prob = 0.8)
+#' # 80% interval of estimated reciprocal_dispersion parameter
+#' posterior_interval(fit6, pars = "reciprocal_dispersion", prob = 0.8)
+#' plot(fit6, "areas", pars = "reciprocal_dispersion", prob = 0.8)
 #' }
 #'
 stan_glm <- function(formula, family = gaussian(), data, weights, subset,

--- a/R/stan_glm.fit.R
+++ b/R/stan_glm.fit.R
@@ -442,7 +442,7 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
       if (is_gaussian) "sigma" else
         if (is_gamma) "shape" else
           if (is_ig) "lambda" else 
-            if (is_nb) "overdispersion" else NA
+            if (is_nb) "reciprocal_dispersion" else NA
     names(out$par) <- new_names
     colnames(out$theta_tilde) <- new_names
     out$stanfit <- suppressMessages(sampling(stanfit, data = standata, 
@@ -512,7 +512,7 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
                    if (is_gaussian) "sigma", 
                    if (is_gamma) "shape", 
                    if (is_ig) "lambda",
-                   if (is_nb) "overdispersion", 
+                   if (is_nb) "reciprocal_dispersion", 
                    if (standata$len_theta_L) paste0("Sigma[", Sigma_nms, "]"),
                    "mean_PPD", 
                    "log-posterior")
@@ -702,5 +702,5 @@ summarize_glm_prior <-
   if (is.gaussian(fam)) "sigma" else
     if (is.gamma(fam)) "shape" else
       if (is.ig(fam)) "lambda" else 
-        if (is.nb(fam)) "overdispersion" else NA
+        if (is.nb(fam)) "reciprocal_dispersion" else NA
 }

--- a/R/stan_glm.fit.R
+++ b/R/stan_glm.fit.R
@@ -30,7 +30,7 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
                          ...,
                          prior = normal(),
                          prior_intercept = normal(),
-                         prior_dispersion = cauchy(0, 5),
+                         prior_nuisance = cauchy(0, 5),
                          prior_ops = NULL,
                          group = list(),
                          prior_PD = FALSE, 
@@ -42,10 +42,10 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
   # removed in future release
   if (!is.null(prior_ops)) {
     tmp <- .support_deprecated_prior_options(prior, prior_intercept, 
-                                             prior_dispersion, prior_ops)
+                                             prior_nuisance, prior_ops)
     prior <- tmp[["prior"]]
     prior_intercept <- tmp[["prior_intercept"]]
-    prior_dispersion <- tmp[["prior_dispersion"]]
+    prior_nuisance <- tmp[["prior_nuisance"]]
     prior_ops <- NULL
   }
   
@@ -93,10 +93,10 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
 
   # useless assignments to pass R CMD check
   has_intercept <- 
-    prior_df <- prior_df_for_intercept <- prior_df_for_dispersion <-
-    prior_dist <- prior_dist_for_intercept <- prior_dist_for_dispersion <- 
-    prior_mean <- prior_mean_for_intercept <- prior_mean_for_dispersion <- 
-    prior_scale <- prior_scale_for_intercept <- prior_scale_for_dispersion <- 
+    prior_df <- prior_df_for_intercept <- prior_df_for_nuisance <-
+    prior_dist <- prior_dist_for_intercept <- prior_dist_for_nuisance <- 
+    prior_mean <- prior_mean_for_intercept <- prior_mean_for_nuisance <- 
+    prior_scale <- prior_scale_for_intercept <- prior_scale_for_nuisance <- 
     prior_autoscale <- prior_autoscale_for_intercept <- NULL
   
   x_stuff <- center_x(x, sparse)
@@ -106,7 +106,7 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
 
   ok_dists <- nlist("normal", student_t = "t", "cauchy", "hs", "hs_plus")
   ok_intercept_dists <- ok_dists[1:3]
-  ok_dispersion_dists <- c(ok_dists[1:3], exponential = "exponential")
+  ok_nuisance_dists <- c(ok_dists[1:3], exponential = "exponential")
   
   # prior distributions
   prior_stuff <- handle_glm_prior(
@@ -132,18 +132,18 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
   for (i in names(prior_intercept_stuff))
     assign(i, prior_intercept_stuff[[i]])
   
-  prior_dispersion_stuff <-
+  prior_nuisance_stuff <-
     handle_glm_prior(
-      prior_dispersion,
+      prior_nuisance,
       nvars = 1,
       default_scale = 5,
       link = NULL, # don't need to adjust scale based on logit vs probit
-      ok_dists = ok_dispersion_dists
+      ok_dists = ok_nuisance_dists
     )
-  # prior_{dist, mean, scale, df, dist_name, autoscale}_for_dispersion
-  names(prior_dispersion_stuff) <- paste0(names(prior_dispersion_stuff), "_for_dispersion")
-  for (i in names(prior_dispersion_stuff)) 
-    assign(i, prior_dispersion_stuff[[i]])
+  # prior_{dist, mean, scale, df, dist_name, autoscale}_for_nuisance
+  names(prior_nuisance_stuff) <- paste0(names(prior_nuisance_stuff), "_for_nuisance")
+  for (i in names(prior_nuisance_stuff)) 
+    assign(i, prior_nuisance_stuff[[i]])
   
   famname <- supported_families[fam]
   is_bernoulli <- is.binomial(famname) && all(y %in% 0:1)
@@ -223,8 +223,8 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
     prior_scale_for_intercept = c(prior_scale_for_intercept),
     prior_mean_for_intercept = c(prior_mean_for_intercept),
     prior_df_for_intercept = c(prior_df_for_intercept),
-    prior_dist_for_dispersion = prior_dist_for_dispersion
-    # mean,df,scale for dispersion added below depending on family
+    prior_dist_for_nuisance = prior_dist_for_nuisance
+    # mean,df,scale for nuisance added below depending on family
   )
 
   # make a copy of user specification before modifying 'group' (used for keeping
@@ -321,20 +321,20 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
 
   # call stan() to draw from posterior distribution
   if (is_continuous) {
-    standata$prior_scale_for_dispersion <- prior_scale_for_dispersion %ORifINF% 0
-    standata$prior_df_for_dispersion <- c(prior_df_for_dispersion)
-    standata$prior_mean_for_dispersion <- c(prior_mean_for_dispersion)
+    standata$prior_scale_for_nuisance <- prior_scale_for_nuisance %ORifINF% 0
+    standata$prior_df_for_nuisance <- c(prior_df_for_nuisance)
+    standata$prior_mean_for_nuisance <- c(prior_mean_for_nuisance)
     standata$family <- switch(family$family, 
                               gaussian = 1L, 
                               Gamma = 2L,
                               3L)
     stanfit <- stanmodels$continuous
   } else if (is.binomial(famname)) {
-    standata$prior_scale_for_dispersion <- 
-      if (!length(group) || prior_scale_for_dispersion == Inf) 
-        0 else prior_scale_for_dispersion
-    standata$prior_mean_for_dispersion <- 0
-    standata$prior_df_for_dispersion <- 0
+    standata$prior_scale_for_nuisance <- 
+      if (!length(group) || prior_scale_for_nuisance == Inf) 
+        0 else prior_scale_for_nuisance
+    standata$prior_mean_for_nuisance <- 0
+    standata$prior_df_for_nuisance <- 0
     standata$family <- 1L # not actually used
     if (is_bernoulli) {
       y0 <- y == 0
@@ -392,15 +392,15 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
     }
   } else if (is.poisson(famname)) {
     standata$family <- 1L
-    standata$prior_scale_for_dispersion <- prior_scale_for_dispersion %ORifINF% 0
-    standata$prior_mean_for_dispersion <- 0
-    standata$prior_df_for_dispersion <- 0
+    standata$prior_scale_for_nuisance <- prior_scale_for_nuisance %ORifINF% 0
+    standata$prior_mean_for_nuisance <- 0
+    standata$prior_df_for_nuisance <- 0
     stanfit <- stanmodels$count 
   } else if (is_nb) {
     standata$family <- 2L
-    standata$prior_scale_for_dispersion <- prior_scale_for_dispersion %ORifINF% 0
-    standata$prior_df_for_dispersion <- c(prior_df_for_dispersion)
-    standata$prior_mean_for_dispersion <- c(prior_mean_for_dispersion)
+    standata$prior_scale_for_nuisance <- prior_scale_for_nuisance %ORifINF% 0
+    standata$prior_df_for_nuisance <- c(prior_df_for_nuisance)
+    standata$prior_mean_for_nuisance <- c(prior_mean_for_nuisance)
     stanfit <- stanmodels$count
   } else if (is_gamma) {
     # nothing
@@ -412,7 +412,7 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
   prior_info <- summarize_glm_prior(
     user_prior = prior_stuff,
     user_prior_intercept = prior_intercept_stuff,
-    user_prior_dispersion = prior_dispersion_stuff,
+    user_prior_nuisance = prior_nuisance_stuff,
     user_prior_covariance = user_covariance,
     has_intercept = has_intercept,
     has_predictors = nvars > 0,
@@ -424,7 +424,7 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
   pars <- c(if (has_intercept) "alpha", 
             "beta", 
             if (length(group)) "b",
-            if (is_continuous | is_nb) "dispersion",
+            if (is_continuous | is_nb) "nuisance",
             if (standata$len_theta_L) "theta_L",
             "mean_PPD")
   if (algorithm == "optimizing") {
@@ -438,7 +438,7 @@ stan_glm.fit <- function(x, y, weights = rep(1, NROW(x)),
     }
     new_names[mark] <- colnames(xtemp)
     new_names[new_names == "alpha[1]"] <- "(Intercept)"
-    new_names[grepl("dispersion(\\[1\\])?$", new_names)] <- 
+    new_names[grepl("nuisance(\\[1\\])?$", new_names)] <- 
       if (is_gaussian) "sigma" else
         if (is_gamma) "shape" else
           if (is_ig) "lambda" else 
@@ -602,19 +602,19 @@ make_b_nms <- function(group) {
 # Create "prior.info" attribute needed for prior_summary()
 #
 # @param user_* The user's prior, prior_intercept, prior_covariance, and 
-#   prior_dispersion specifications. For prior and prior_intercept these should be
+#   prior_nuisance specifications. For prior and prior_intercept these should be
 #   passed in after broadcasting the df/location/scale arguments if necessary.
 # @param has_intercept T/F, does model have an intercept?
 # @param has_predictors T/F, does model have predictors?
 # @param adjusted_prior_* adjusted scales computed if using autoscaled priors
 # @param family Family object.
 # @return A named list with components 'prior', 'prior_intercept', and possibly 
-#   'prior_covariance' and 'prior_dispersion' each of which itself is a list
+#   'prior_covariance' and 'prior_nuisance' each of which itself is a list
 #   containing the needed values for prior_summary.
 summarize_glm_prior <-
   function(user_prior,
            user_prior_intercept,
-           user_prior_dispersion,
+           user_prior_nuisance,
            user_prior_covariance,
            has_intercept, 
            has_predictors,
@@ -647,11 +647,11 @@ summarize_glm_prior <-
         user_prior_intercept$prior_dist_name_for_intercept <- "student_t"
       }
     }
-    if (user_prior_dispersion$prior_dist_name_for_dispersion %in% "t") {
-      if (all(user_prior_dispersion$prior_df_for_dispersion == 1)) {
-        user_prior_dispersion$prior_dist_name_for_dispersion <- "cauchy"
+    if (user_prior_nuisance$prior_dist_name_for_nuisance %in% "t") {
+      if (all(user_prior_nuisance$prior_df_for_nuisance == 1)) {
+        user_prior_nuisance$prior_dist_name_for_nuisance <- "cauchy"
       } else {
-        user_prior_dispersion$prior_dist_name_for_dispersion <- "student_t"
+        user_prior_nuisance$prior_dist_name_for_nuisance <- "student_t"
       }
     }
     prior_list <- list(
@@ -679,25 +679,25 @@ summarize_glm_prior <-
     if (length(user_prior_covariance))
       prior_list$prior_covariance <- user_prior_covariance
     
-    dispersion_name <- .rename_dispersion(family)
-    prior_list$prior_dispersion <- if (is.na(dispersion_name)) 
-      NULL else with(user_prior_dispersion, list(
-        dist = prior_dist_name_for_dispersion,
-        location = if (prior_dist_name_for_dispersion != "exponential")
-          prior_mean_for_dispersion else NULL,
-        scale = if (prior_dist_name_for_dispersion != "exponential")
-          prior_scale_for_dispersion else NULL,
-        df = if (prior_dist_name_for_dispersion %in% "student_t")
-          prior_df_for_dispersion else NULL, 
-        rate = if (prior_dist_name_for_dispersion %in% "exponential")
-          1 / prior_scale_for_dispersion else NULL,
-        dispersion_name = dispersion_name
+    nuisance_name <- .rename_nuisance(family)
+    prior_list$prior_nuisance <- if (is.na(nuisance_name)) 
+      NULL else with(user_prior_nuisance, list(
+        dist = prior_dist_name_for_nuisance,
+        location = if (prior_dist_name_for_nuisance != "exponential")
+          prior_mean_for_nuisance else NULL,
+        scale = if (prior_dist_name_for_nuisance != "exponential")
+          prior_scale_for_nuisance else NULL,
+        df = if (prior_dist_name_for_nuisance %in% "student_t")
+          prior_df_for_nuisance else NULL, 
+        rate = if (prior_dist_name_for_nuisance %in% "exponential")
+          1 / prior_scale_for_nuisance else NULL,
+        nuisance_name = nuisance_name
       ))
       
     return(prior_list)
   }
 
-.rename_dispersion <- function(family) {
+.rename_nuisance <- function(family) {
   fam <- family$family
   if (is.gaussian(fam)) "sigma" else
     if (is.gamma(fam)) "shape" else

--- a/R/stan_glmer.R
+++ b/R/stan_glmer.R
@@ -61,9 +61,8 @@
 #'   \code{family = gaussian(link = "identity")}. 
 #'   
 #'   The \code{stan_glmer.nb} function, which takes the extra argument 
-#'   \code{link}, is a simple wrapper for \code{stan_glmer} with \code{family = 
-#'   \link{neg_binomial_2}(link)}. The \code{prior_nuisance} argument can be
-#'   used to set a prior on the overdispersion parameter.
+#'   \code{link}, is a wrapper for \code{stan_glmer} with \code{family = 
+#'   \link{neg_binomial_2}(link)}.
 #'   
 #'   
 #' @seealso The vignette for \code{stan_glmer} and the \emph{Hierarchical 

--- a/R/stan_glmer.R
+++ b/R/stan_glmer.R
@@ -62,7 +62,7 @@
 #'   
 #'   The \code{stan_glmer.nb} function, which takes the extra argument 
 #'   \code{link}, is a simple wrapper for \code{stan_glmer} with \code{family = 
-#'   \link{neg_binomial_2}(link)}. The \code{prior_dispersion} argument can be
+#'   \link{neg_binomial_2}(link)}. The \code{prior_nuisance} argument can be
 #'   used to set a prior on the overdispersion parameter.
 #'   
 #'   
@@ -81,7 +81,7 @@ stan_glmer <- function(formula, data = NULL, family = gaussian,
                        na.action = getOption("na.action", "na.omit"), 
                        offset, contrasts = NULL, ...,
                        prior = normal(), prior_intercept = normal(),
-                       prior_dispersion = cauchy(0, 5),
+                       prior_nuisance = cauchy(0, 5),
                        prior_covariance = decov(), prior_PD = FALSE, 
                        algorithm = c("sampling", "meanfield", "fullrank"), 
                        adapt_delta = NULL, QR = FALSE, sparse = FALSE) {
@@ -91,7 +91,7 @@ stan_glmer <- function(formula, data = NULL, family = gaussian,
   family <- validate_family(family)
   mc[[1]] <- quote(lme4::glFormula)
   mc$control <- make_glmerControl()
-  mc$prior <- mc$prior_intercept <- mc$prior_covariance <- mc$prior_dispersion <-
+  mc$prior <- mc$prior_intercept <- mc$prior_covariance <- mc$prior_nuisance <-
     mc$prior_PD <- mc$algorithm <- mc$scale <- mc$concentration <- mc$shape <-
     mc$adapt_delta <- mc$... <- mc$QR <- mc$sparse <- NULL
   glmod <- eval(mc, parent.frame())
@@ -106,8 +106,8 @@ stan_glmer <- function(formula, data = NULL, family = gaussian,
     prior <- list()
   if (is.null(prior_intercept)) 
     prior_intercept <- list()
-  if (is.null(prior_dispersion)) 
-    prior_dispersion <- list()
+  if (is.null(prior_nuisance)) 
+    prior_nuisance <- list()
   if (is.null(prior_covariance))
     stop("'prior_covariance' can't be NULL.", call. = FALSE)
   group <- glmod$reTrms
@@ -116,7 +116,7 @@ stan_glmer <- function(formula, data = NULL, family = gaussian,
   stanfit <- stan_glm.fit(x = X, y = y, weights = weights,
                           offset = offset, family = family,
                           prior = prior, prior_intercept = prior_intercept,
-                          prior_dispersion = prior_dispersion, prior_PD = prior_PD, 
+                          prior_nuisance = prior_nuisance, prior_PD = prior_PD, 
                           algorithm = algorithm, adapt_delta = adapt_delta,
                           group = group, QR = QR, sparse = sparse, ...)
 
@@ -166,7 +166,7 @@ stan_lmer <- function(formula,
                       ...,
                       prior = normal(),
                       prior_intercept = normal(),
-                      prior_dispersion = cauchy(0, 5),
+                      prior_nuisance = cauchy(0, 5),
                       prior_covariance = decov(),
                       prior_PD = FALSE,
                       algorithm = c("sampling", "meanfield", "fullrank"),
@@ -202,7 +202,7 @@ stan_glmer.nb <- function(formula,
                           ...,
                           prior = normal(),
                           prior_intercept = normal(),
-                          prior_dispersion = cauchy(0, 5),
+                          prior_nuisance = cauchy(0, 5),
                           prior_covariance = decov(),
                           prior_PD = FALSE,
                           algorithm = c("sampling", "meanfield", "fullrank"),

--- a/R/stan_polr.fit.R
+++ b/R/stan_polr.fit.R
@@ -105,7 +105,7 @@ stan_polr.fit <- function(x, y, wt = NULL, offset = NULL,
                     is_skewed, shape, rate,
                     # the rest of these are not actually used
                     family = 1L, has_intercept = 0L, 
-                    prior_dist_for_intercept = 0L, prior_dist_for_dispersion = 0L, 
+                    prior_dist_for_intercept = 0L, prior_dist_for_nuisance = 0L, 
                     dense_X = TRUE, # sparse is not a viable option
                     nnz_X = 0L, w_X = double(0), v_X = integer(0), u_X = integer(0))
   stanfit <- stanmodels$polr

--- a/exec/bernoulli.stan
+++ b/exec/bernoulli.stan
@@ -37,7 +37,7 @@ data {
   vector[has_offset ? N[1] : 0] offset0;
   vector[has_offset ? N[2] : 0] offset1;
   
-  // declares prior_{mean, scale, df}, prior_{mean, scale, df}_for_intercept, prior_scale_for dispersion
+  // declares prior_{mean, scale, df}, prior_{mean, scale, df}_for_intercept, prior_scale_for nuisance
   #include "hyperparameters.stan"
   // declares t, p[t], l[t], q, len_theta_L, shape, scale, {len_}concentration, {len_}regularization
   #include "glmer_stuff.stan"  

--- a/exec/binomial.stan
+++ b/exec/binomial.stan
@@ -12,7 +12,7 @@ data {
   int<lower=0> trials[N];  // number of trials
   #include "data_glm.stan" // declares prior_PD, has_intercept, family, link, prior_dist, prior_dist_for_intercept
   #include "weights_offset.stan"  // declares has_weights, weights, has_offset, offset
-  // declares prior_{mean, scale, df}, prior_{mean, scale, df}_for_intercept, prior_scale_for dispersion
+  // declares prior_{mean, scale, df}, prior_{mean, scale, df}_for_intercept, prior_scale_for nuisance
   #include "hyperparameters.stan"
   // declares t, p[t], l[t], q, len_theta_L, shape, scale, {len_}concentration, {len_}regularization
   #include "glmer_stuff.stan"  

--- a/exec/continuous.stan
+++ b/exec/continuous.stan
@@ -28,7 +28,7 @@ data {
   vector[N] y; // continuous outcome
   #include "data_glm.stan" // declares prior_PD, has_intercept, family, link, prior_dist, prior_dist_for_intercept
   #include "weights_offset.stan"  // declares has_weights, weights, has_offset, offset
-  // declares prior_{mean, scale, df}, prior_{mean, scale, df}_for_intercept, prior_scale_for dispersion
+  // declares prior_{mean, scale, df}, prior_{mean, scale, df}_for_intercept, prior_scale_for nuisance
   #include "hyperparameters.stan"
   // declares t, p[t], l[t], q, len_theta_L, shape, scale, {len_}concentration, {len_}regularization
   #include "glmer_stuff.stan"  
@@ -47,23 +47,23 @@ transformed data {
 parameters {
   real<lower=(family == 1 || link == 2 ? negative_infinity() : 0.0)> gamma[has_intercept];
   #include "parameters_glm.stan" // declares z_beta, global, local, z_b, z_T, rho, zeta, tau
-  real<lower=0> dispersion_unscaled; # interpretation depends on family!
+  real<lower=0> nuisance_unscaled; # interpretation depends on family!
 }
 transformed parameters {
-  real dispersion;
+  real nuisance;
   #include "tparameters_glm.stan" // defines beta, b, theta_L
   
-  if (prior_dist_for_dispersion == 0)
-    dispersion = dispersion_unscaled;
+  if (prior_dist_for_nuisance == 0)
+    nuisance = nuisance_unscaled;
   else {
-    dispersion = prior_scale_for_dispersion * dispersion_unscaled;
-    if (prior_dist_for_dispersion <= 2) // normal or student_t
-      dispersion = dispersion + prior_mean_for_dispersion;
+    nuisance = prior_scale_for_nuisance * nuisance_unscaled;
+    if (prior_dist_for_nuisance <= 2) // normal or student_t
+      nuisance = nuisance + prior_mean_for_nuisance;
   }
     
   if (t > 0) {
     theta_L = make_theta_L(len_theta_L, p, 
-                            dispersion, tau, scale, zeta, rho, z_T);
+                            nuisance, tau, scale, zeta, rho, z_T);
     b = make_b(z_b, theta_L, p, l);
   }
 }
@@ -82,38 +82,38 @@ model {
   if (has_weights == 0 && prior_PD == 0) { # unweighted log-likelihoods
     if (family == 1) {
       if (link == 1) 
-        target += normal_lpdf(y | eta, dispersion);
+        target += normal_lpdf(y | eta, nuisance);
       else if (link == 2) 
-        target += normal_lpdf(y | exp(eta), dispersion);
+        target += normal_lpdf(y | exp(eta), nuisance);
       else 
-        target += normal_lpdf(y | divide_real_by_vector(1, eta), dispersion);
+        target += normal_lpdf(y | divide_real_by_vector(1, eta), nuisance);
       // divide_real_by_vector() is defined in common_functions.stan
     }
     else if (family == 2) {
-      target += GammaReg(y, eta, dispersion, link, sum_log_y);
+      target += GammaReg(y, eta, nuisance, link, sum_log_y);
     }
     else {
       target += inv_gaussian(y, linkinv_inv_gaussian(eta, link), 
-                             dispersion, sum_log_y, sqrt_y);
+                             nuisance, sum_log_y, sqrt_y);
     }
   }
   else if (prior_PD == 0) { # weighted log-likelihoods
     vector[N] summands;
-    if (family == 1) summands = pw_gauss(y, eta, dispersion, link);
-    else if (family == 2) summands = pw_gamma(y, eta, dispersion, link);
-    else summands = pw_inv_gaussian(y, eta, dispersion, link, log_y, sqrt_y);
+    if (family == 1) summands = pw_gauss(y, eta, nuisance, link);
+    else if (family == 2) summands = pw_gamma(y, eta, nuisance, link);
+    else summands = pw_inv_gaussian(y, eta, nuisance, link, log_y, sqrt_y);
     target += dot_product(weights, summands);
   }
 
   // Log-priors
-  if (prior_dist_for_dispersion > 0 && prior_scale_for_dispersion > 0) {
-    if (prior_dist_for_dispersion == 1)
-      target += normal_lpdf(dispersion_unscaled | 0, 1);
-    else if (prior_dist_for_dispersion == 2)
-      target += student_t_lpdf(dispersion_unscaled | 
-                               prior_df_for_dispersion, 0, 1);
+  if (prior_dist_for_nuisance > 0 && prior_scale_for_nuisance > 0) {
+    if (prior_dist_for_nuisance == 1)
+      target += normal_lpdf(nuisance_unscaled | 0, 1);
+    else if (prior_dist_for_nuisance == 2)
+      target += student_t_lpdf(nuisance_unscaled | 
+                               prior_df_for_nuisance, 0, 1);
     else 
-     target += exponential_lpdf(dispersion_unscaled | 1);
+     target += exponential_lpdf(nuisance_unscaled | 1);
   }
     
   #include "priors_glm.stan" // increments target()
@@ -144,15 +144,15 @@ generated quantities {
     
     if (family == 1) {
       if (link > 1) eta = linkinv_gauss(eta, link);
-      for (n in 1:N) mean_PPD = mean_PPD + normal_rng(eta[n], dispersion);
+      for (n in 1:N) mean_PPD = mean_PPD + normal_rng(eta[n], nuisance);
     }
     else if (family == 2) {
       if (link > 1) eta = linkinv_gamma(eta, link);
-      for (n in 1:N) mean_PPD = mean_PPD + gamma_rng(dispersion, dispersion / eta[n]);
+      for (n in 1:N) mean_PPD = mean_PPD + gamma_rng(nuisance, nuisance / eta[n]);
     }
     else if (family == 3) {
       if (link > 1) eta = linkinv_inv_gaussian(eta, link);
-      for (n in 1:N) mean_PPD = mean_PPD + inv_gaussian_rng(eta[n], dispersion);
+      for (n in 1:N) mean_PPD = mean_PPD + inv_gaussian_rng(eta[n], nuisance);
     }
     mean_PPD = mean_PPD / N;
   }

--- a/exec/count.stan
+++ b/exec/count.stan
@@ -11,7 +11,7 @@ data {
   int<lower=0> y[N];  // count outcome
   #include "data_glm.stan" // declares prior_PD, has_intercept, family, link, prior_dist, prior_dist_for_intercept
   #include "weights_offset.stan"  // declares has_weights, weights, has_offset, offset
-  // declares prior_{mean, scale, df}, prior_{mean, scale, df}_for_intercept, prior_scale_for dispersion
+  // declares prior_{mean, scale, df}, prior_{mean, scale, df}_for_intercept, prior_scale_for nuisance
   #include "hyperparameters.stan"
   // declares t, p[t], l[t], q, len_theta_L, shape, scale, {len_}concentration, {len_}regularization
   #include "glmer_stuff.stan"  
@@ -24,19 +24,19 @@ transformed data{
 parameters {
   real<lower=(link == 1 ? negative_infinity() : 0.0)> gamma[has_intercept];
   #include "parameters_glm.stan" // declares z_beta, global, local, z_b, z_T, rho, zeta, tau
-  real<lower=0> dispersion_unscaled[family > 1];
+  real<lower=0> nuisance_unscaled[family > 1];
   vector<lower=0>[N] noise[family == 3]; // do not store this
 }
 transformed parameters {
-  real dispersion[family > 1];
+  real nuisance[family > 1];
   #include "tparameters_glm.stan" // defines beta, b, theta_L
  
-  if (family > 1 && (prior_dist_for_dispersion == 0 || prior_scale_for_dispersion <= 0))
-    dispersion[1] = dispersion_unscaled[1];
+  if (family > 1 && (prior_dist_for_nuisance == 0 || prior_scale_for_nuisance <= 0))
+    nuisance[1] = nuisance_unscaled[1];
   else if (family > 1) {
-    dispersion[1] = prior_scale_for_dispersion * dispersion_unscaled[1];
-    if (prior_dist_for_dispersion <= 2) // normal or student_t
-      dispersion[1] = dispersion[1] + prior_mean_for_dispersion;
+    nuisance[1] = prior_scale_for_nuisance * nuisance_unscaled[1];
+    if (prior_dist_for_nuisance <= 2) // normal or student_t
+      nuisance[1] = nuisance[1] + prior_mean_for_nuisance;
   }
   
   if (t > 0) {
@@ -44,7 +44,7 @@ transformed parameters {
       theta_L = make_theta_L(len_theta_L, p, 1.0,
                               tau, scale, zeta, rho, z_T);
     else
-      theta_L = make_theta_L(len_theta_L, p, dispersion[1],
+      theta_L = make_theta_L(len_theta_L, p, nuisance[1],
                               tau, scale, zeta, rho, z_T);
     b = make_b(z_b, theta_L, p, l);
   }
@@ -61,9 +61,9 @@ model {
   }
   
   if (family == 3) {
-    if      (link == 1) eta = eta + log(dispersion[1]) + log(noise[1]);
-    else if (link == 2) eta = eta * dispersion[1] .* noise[1];
-    else                eta = eta + sqrt(dispersion[1]) + sqrt(noise[1]);
+    if      (link == 1) eta = eta + log(nuisance[1]) + log(noise[1]);
+    else if (link == 2) eta = eta * nuisance[1] .* noise[1];
+    else                eta = eta + sqrt(nuisance[1]) + sqrt(noise[1]);
   }
   
   // Log-likelihood 
@@ -73,30 +73,30 @@ model {
       else target += poisson_lpmf(y | linkinv_count(eta, link));
     }
     else {
-      if (link == 1) target += neg_binomial_2_log_lpmf(y | eta, dispersion[1]);
-      else target += neg_binomial_2_lpmf(y | linkinv_count(eta, link), dispersion[1]);
+      if (link == 1) target += neg_binomial_2_log_lpmf(y | eta, nuisance[1]);
+      else target += neg_binomial_2_lpmf(y | linkinv_count(eta, link), nuisance[1]);
     }
   }
   else if (family != 2 && prior_PD == 0)
     target += dot_product(weights, pw_pois(y, eta, link));
   else if (prior_PD == 0)
-    target += dot_product(weights, pw_nb(y, eta, dispersion[1], link));
+    target += dot_product(weights, pw_nb(y, eta, nuisance[1], link));
   
-  // Log-prior for dispersion
+  // Log-prior for nuisance
   if (family > 1 && 
-      prior_dist_for_dispersion > 0 && prior_scale_for_dispersion > 0) {
-    if (prior_dist_for_dispersion == 1)
-      target += normal_lpdf(dispersion_unscaled | 0, 1);
-    else if (prior_dist_for_dispersion == 2)
-      target += student_t_lpdf(dispersion_unscaled | prior_df_for_dispersion, 0, 1);
+      prior_dist_for_nuisance > 0 && prior_scale_for_nuisance > 0) {
+    if (prior_dist_for_nuisance == 1)
+      target += normal_lpdf(nuisance_unscaled | 0, 1);
+    else if (prior_dist_for_nuisance == 2)
+      target += student_t_lpdf(nuisance_unscaled | prior_df_for_nuisance, 0, 1);
     else 
-      target += exponential_lpdf(dispersion_unscaled | 1);
+      target += exponential_lpdf(nuisance_unscaled | 1);
   }
   
   #include "priors_glm.stan" // increments target()
   
   // Log-prior for noise
-  if (family == 3) target += gamma_lpdf(noise[1] | dispersion[1], 1);
+  if (family == 3) target += gamma_lpdf(noise[1] | nuisance[1], 1);
   
   if (t > 0) decov_lp(z_b, z_T, rho, zeta, tau, 
                       regularization, delta, shape, t, p);
@@ -126,9 +126,9 @@ generated quantities {
     }
     
     if (family == 3) {
-      if      (link == 1) eta = eta + log(dispersion[1]) + log(noise[1]);
-      else if (link == 2) eta = eta * dispersion[1] .* noise[1];
-      else                eta = eta + sqrt(dispersion[1]) + sqrt(noise[1]);
+      if      (link == 1) eta = eta + log(nuisance[1]) + log(noise[1]);
+      else if (link == 2) eta = eta * nuisance[1] .* noise[1];
+      else                eta = eta + sqrt(nuisance[1]) + sqrt(noise[1]);
     }
     nu = linkinv_count(eta, link);
     if (family != 2) for (n in 1:N) {
@@ -137,8 +137,8 @@ generated quantities {
     }
     else for (n in 1:N) {
         real gamma_temp;
-        if (is_inf(dispersion[1])) gamma_temp = nu[n];
-        else gamma_temp = gamma_rng(dispersion[1], dispersion[1] / nu[n]);
+        if (is_inf(nuisance[1])) gamma_temp = nu[n];
+        else gamma_temp = gamma_rng(nuisance[1], nuisance[1] / nu[n]);
         if (gamma_temp < poisson_max)
           mean_PPD = mean_PPD + poisson_rng(gamma_temp);
         else mean_PPD = mean_PPD + normal_rng(gamma_temp, sqrt(gamma_temp));

--- a/inst/chunks/count_likelihoods.stan
+++ b/inst/chunks/count_likelihoods.stan
@@ -43,7 +43,7 @@
   *
   * @param y The integer array corresponding to the outcome variable.
   * @param eta The vector of linear predictors
-  * @param theta The overdispersion parameter
+  * @param theta The reciprocal_dispersion parameter
   * @param link An integer indicating the link function
   * @return A vector
   */

--- a/inst/chunks/data_glm.stan
+++ b/inst/chunks/data_glm.stan
@@ -15,5 +15,5 @@
   int<lower=0,upper=2> prior_dist_for_intercept;
   
   // prior family: 0 = none, 1 = normal, 2 = student_t, 3 = exponential
-  int<lower=0,upper=3> prior_dist_for_dispersion;
+  int<lower=0,upper=3> prior_dist_for_nuisance;
   

--- a/inst/chunks/hyperparameters.stan
+++ b/inst/chunks/hyperparameters.stan
@@ -1,10 +1,10 @@
   // hyperparameter values are set to 0 if there is no prior
   vector<lower=0>[K] prior_scale;
   real<lower=0> prior_scale_for_intercept;
-  real<lower=0> prior_scale_for_dispersion;
+  real<lower=0> prior_scale_for_nuisance;
   vector[K] prior_mean;
   real prior_mean_for_intercept;
-  real<lower=0> prior_mean_for_dispersion;
+  real<lower=0> prior_mean_for_nuisance;
   vector<lower=0>[K] prior_df;
   real<lower=0> prior_df_for_intercept;
-  real<lower=0> prior_df_for_dispersion;
+  real<lower=0> prior_df_for_nuisance;

--- a/man-roxygen/args-priors.R
+++ b/man-roxygen/args-priors.R
@@ -19,15 +19,19 @@
 #'   \code{sparse} argument is left at its default value of \code{FALSE}--- then
 #'   the prior distribution for the intercept is set so it applies to the value 
 #'   when all predictors are centered.)
-#' @param prior_dispersion The prior distribution for the "dispersion" parameter
-#'   (if applicable). The "dispersion" parameter refers to a different parameter
-#'   depending on the \code{family}. For Gaussian models it is the residual SD 
-#'   sigma, for negative binomial models it is the overdispersion parameter, for
-#'   gamma models it is the shape parameter, and for inverse-Gaussian models it 
-#'   is the lambda parameter. Binomial and Poisson models do not have dispersion
-#'   parameters. \code{prior_dispersion} can be a call to \code{exponential} to 
+#' @param prior_nuisance The prior distribution for the "nuisance" parameter (if
+#'   applicable). The "nuisance" parameter refers to a different parameter 
+#'   depending on the \code{family}. For Gaussian models it refers to the error 
+#'   standard deviation \code{"sigma"}. For negative binomial models it is the 
+#'   so-called \code{"size"} parameter (see e.g., \code{\link[stats]{rnbinom}}),
+#'   and smaller values of \code{"size"} correspond to greater (over)dispersion.
+#'   For gamma models it is the \code{"shape"} parameter (see e.g., 
+#'   \code{\link[stats]{rgamma}}), and for inverse-Gaussian models it is the 
+#'   so-called \code{"lambda"} parameter (which is essentially the reciprocal of
+#'   a scale parameter). Binomial and Poisson models do not have nuisance 
+#'   parameters. \code{prior_nuisance} can be a call to \code{exponential} to 
 #'   use an exponential distribution, or \code{normal}, \code{student_t} or 
 #'   \code{cauchy}, which results in a half-normal, half-t, or half-Cauchy 
-#'   prior. See \code{\link{priors}} for details on these functions. To omit 
-#'   a prior ---i.e., to use a flat (improper) uniform prior--- set 
-#'   \code{prior_dispersion} to \code{NULL}.
+#'   prior. See \code{\link{priors}} for details on these functions. To omit a 
+#'   prior ---i.e., to use a flat (improper) uniform prior--- set 
+#'   \code{prior_nuisance} to \code{NULL}.

--- a/man-roxygen/args-priors.R
+++ b/man-roxygen/args-priors.R
@@ -21,15 +21,20 @@
 #'   when all predictors are centered.)
 #' @param prior_nuisance The prior distribution for the "nuisance" parameter (if
 #'   applicable). The "nuisance" parameter refers to a different parameter 
-#'   depending on the \code{family}. For Gaussian models it refers to the error 
-#'   standard deviation \code{"sigma"}. For negative binomial models it is the 
-#'   so-called \code{"size"} parameter (see e.g., \code{\link[stats]{rnbinom}}),
-#'   and smaller values of \code{"size"} correspond to greater (over)dispersion.
-#'   For gamma models it is the \code{"shape"} parameter (see e.g., 
+#'   depending on the \code{family}. For Gaussian models \code{prior_nuisance} 
+#'   controls \code{"sigma"}, the error 
+#'   standard deviation. For negative binomial models \code{prior_nuisance} controls 
+#'   \code{"reciprocal_dispersion"}, which is similar to the 
+#'   \code{"size"} parameter of \code{\link[stats]{rnbinom}}:
+#'   smaller values of \code{"reciprocal_dispersion"} correspond to 
+#'   greater dispersion. For gamma models \code{prior_nuisance} sets the prior on 
+#'   to the \code{"shape"} parameter (see e.g., 
 #'   \code{\link[stats]{rgamma}}), and for inverse-Gaussian models it is the 
 #'   so-called \code{"lambda"} parameter (which is essentially the reciprocal of
 #'   a scale parameter). Binomial and Poisson models do not have nuisance 
-#'   parameters. \code{prior_nuisance} can be a call to \code{exponential} to 
+#'   parameters. 
+#'   
+#'   \code{prior_nuisance} can be a call to \code{exponential} to 
 #'   use an exponential distribution, or \code{normal}, \code{student_t} or 
 #'   \code{cauchy}, which results in a half-normal, half-t, or half-Cauchy 
 #'   prior. See \code{\link{priors}} for details on these functions. To omit a 

--- a/tests/testthat/test_methods.R
+++ b/tests/testthat/test_methods.R
@@ -581,7 +581,7 @@ test_that("print and summary methods ok for optimization", {
   treatment <- gl(3,3)
   fit <- stan_glm.nb(counts ~ outcome + treatment, algorithm = "optimizing",
                      seed = SEED)
-  expect_output(print(fit), "overdispersion")
+  expect_output(print(fit), "reciprocal_dispersion")
 
   clotting <- data.frame(log_u = log(c(5,10,15,20,30,40,60,80,100)),
                          lot1 = c(118,58,42,35,27,25,21,19,18),

--- a/tests/testthat/test_methods.R
+++ b/tests/testthat/test_methods.R
@@ -36,7 +36,7 @@ glm1 <- glm(mpg ~ wt + cyl, data = mtcars)
 lmer1 <- lmer(diameter ~ (1|plate) + (1|sample), data = Penicillin)
 stan_lmer1 <- SW(stan_lmer(diameter ~ (1|plate) + (1|sample), data = Penicillin,
                            prior_intercept = normal(0, 50, autoscale = FALSE),
-                           prior_dispersion = normal(0, 10),
+                           prior_nuisance = normal(0, 10),
                            iter = ITER, chains = CHAINS, seed = SEED, refresh = REFRESH))
 lmer2 <- lmer(Reaction ~ Days + (Days | Subject), data = sleepstudy)
 stan_lmer2 <- SW(stan_lmer(Reaction ~ Days + (Days | Subject), data = sleepstudy,
@@ -680,13 +680,13 @@ test_that("prior_summary returns correctly named list", {
   expect_named(prior_summary(example_model),
                 c("prior", "prior_intercept", "prior_covariance"))
   expect_named(prior_summary(stan_lmer1),
-               c("prior", "prior_intercept", "prior_covariance", "prior_dispersion"))
+               c("prior", "prior_intercept", "prior_covariance", "prior_nuisance"))
   expect_named(prior_summary(stan_lmer2),
-               c("prior", "prior_intercept", "prior_covariance", "prior_dispersion"))
+               c("prior", "prior_intercept", "prior_covariance", "prior_nuisance"))
   expect_named(prior_summary(stan_polr1),
                c("prior", "prior_counts"))
   expect_named(prior_summary(stan_glm_opt1),
-               c("prior", "prior_intercept", "prior_dispersion"))
+               c("prior", "prior_intercept", "prior_nuisance"))
   expect_named(prior_summary(stan_glm_vb1),
-               c("prior", "prior_intercept", "prior_dispersion"))
+               c("prior", "prior_intercept", "prior_nuisance"))
 })

--- a/tests/testthat/test_stan_glm.R
+++ b/tests/testthat/test_stan_glm.R
@@ -239,14 +239,14 @@ test_that("model with hs prior doesn't error", {
                 regexp = "Automatic Differentiation Variational Inference")
 })
 
-test_that("prior_dispersion argument is detected properly", {
+test_that("prior_nuisance argument is detected properly", {
   fit <- stan_glm(mpg ~ wt, data = mtcars, iter = 10, chains = 1, seed = SEED, 
-                  refresh = -1, prior_dispersion = exponential(5))
+                  refresh = -1, prior_nuisance = exponential(5))
   expect_identical(
-    fit$prior.info$prior_dispersion, 
+    fit$prior.info$prior_nuisance, 
     list(dist = "exponential", 
          location = NULL, scale = NULL, df = NULL, rate = 5, 
-         dispersion_name = "sigma")
+         nuisance_name = "sigma")
   )
 })
 

--- a/tests/testthat/test_stan_glm.R
+++ b/tests/testthat/test_stan_glm.R
@@ -45,9 +45,9 @@ test_that("stan_glm throws appropriate errors, warnings, and messages", {
   
   # error: prior and prior_intercept not lists
   expect_error(stan_glm(f, family = "poisson", prior = normal), 
-               regexp = "'prior' should be a named list")
+               regexp = "should be a named list")
   expect_error(stan_glm(f, family = "poisson", prior_intercept = normal), 
-               regexp = "'prior_intercept' should be a named list")
+               regexp = "should be a named list")
   
   # error: QR only with more than 1 predictor
   expect_error(stan_glm(counts ~ 1, family = "poisson", QR = TRUE), 


### PR DESCRIPTION
* Renames `dispersion` to `nuisance` pretty much everywhere it's used
* Renames `overdispersion` to `reciprocal_dispersion` in output from negative binomial models. 

"nuisance" is not an ideal term but currently it's "dispersion" regardless of whether that makes sense for the given model. "nuisance"  is less misleading. 