### PR TITLE
Deprecate omitting data argument

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -684,3 +684,19 @@ check_stanfit <- function(x) {
   }
   return(TRUE)
 }
+
+# Throw a deprecation warning if 'data' argument to modeling function is missing
+# @param fun The name of a function
+warn_data_arg_missing <- function(fun) {
+  warning("Omitting the 'data' argument to ", fun, " is deprecated ",
+          "and will not be allowed in the next release of rstanarm.", 
+          call. = FALSE)
+}
+
+# Throw an error if 'data' argument to modeling function is missing
+# @param fun The name of a function
+stop_data_arg_missing <- function(fun) {
+  stop("The 'data' argument is required for ", fun, 
+       call. = FALSE)
+}
+

--- a/R/misc.R
+++ b/R/misc.R
@@ -685,18 +685,14 @@ check_stanfit <- function(x) {
   return(TRUE)
 }
 
-# Throw a deprecation warning if 'data' argument to modeling function is missing
+# Throw a warning if 'data' argument to modeling function is missing
 # @param fun The name of a function
 warn_data_arg_missing <- function(fun) {
-  warning("Omitting the 'data' argument to ", fun, " is deprecated ",
-          "and will not be allowed in the next release of rstanarm.", 
-          call. = FALSE)
-}
-
-# Throw an error if 'data' argument to modeling function is missing
-# @param fun The name of a function
-stop_data_arg_missing <- function(fun) {
-  stop("The 'data' argument is required for ", fun, 
-       call. = FALSE)
+  warning(
+    "Omitting the 'data' argument to ", fun, " is not recommended ",
+    "and may not be allowed in the future versions of rstanarm. ", 
+    "Some post-estimation functions (in particular 'update', 'loo', 'kfold') ", 
+    "are not guaranteed to work properly unless 'data' is specified as a data frame.",
+    call. = FALSE)
 }
 

--- a/R/stan_aov.R
+++ b/R/stan_aov.R
@@ -28,14 +28,17 @@
 #'          prior = R2(0.5), seed = 12345) 
 #' }
 #'             
-stan_aov <- function(formula, data = NULL, projections = FALSE,
+stan_aov <- function(formula, data, projections = FALSE,
                      contrasts = NULL, ...,
                      prior = R2(stop("'location' must be specified")), 
                      prior_PD = FALSE, 
                      algorithm = c("sampling", "meanfield", "fullrank"), 
                      adapt_delta = NULL) {
+    if (missing(data)) 
+      warn_data_arg_missing("stan_aov")
+  
     # parse like aov() does
-    Terms <- if(missing(data)) 
+    Terms <- if (missing(data)) 
       terms(formula, "Error") else terms(formula, "Error", data = data)
     indError <- attr(Terms, "specials")$Error
     ## NB: this is only used for n > 1, so singular form makes no sense

--- a/R/stan_betareg.R
+++ b/R/stan_betareg.R
@@ -123,6 +123,10 @@ stan_betareg <-
            algorithm = c("sampling", "optimizing", "meanfield", "fullrank"),
            adapt_delta = NULL,
            QR = FALSE) {
+    
+    if (missing(data)) 
+      warn_data_arg_missing("stan_betareg")
+    
     if (!requireNamespace("betareg", quietly = TRUE))
       stop("Please install the betareg package before using 'stan_betareg'.")
     

--- a/R/stan_gamm4.R
+++ b/R/stan_gamm4.R
@@ -35,7 +35,7 @@
 #' @template args-sparse
 #' 
 #' @param formula,random,family,data,knots,drop.unused.levels Same as for 
-#'   \code{\link[gamm4]{gamm4}}.
+#'   \code{\link[gamm4]{gamm4}} except \code{data} can't be omitted.
 #' @param subset,weights,na.action Same as \code{\link[stats]{glm}}, 
 #'   but rarely specified.
 #' @param ... Further arguments passed to \code{\link[rstan]{sampling}} (e.g. 
@@ -110,7 +110,7 @@
 #' }
 #' 
 #' @importFrom lme4 getME
-stan_gamm4 <- function(formula, random = NULL, family = gaussian(), data = list(), 
+stan_gamm4 <- function(formula, random = NULL, family = gaussian(), data, 
                        weights = NULL, subset = NULL, na.action, knots = NULL, 
                        drop.unused.levels = TRUE, ..., 
                        prior = normal(), prior_intercept = normal(),
@@ -119,6 +119,11 @@ stan_gamm4 <- function(formula, random = NULL, family = gaussian(), data = list(
                        algorithm = c("sampling", "meanfield", "fullrank"), 
                        adapt_delta = NULL, QR = FALSE, sparse = FALSE) {
 
+  if (missing(data)) {
+    data <- list()
+    warn_data_arg_missing("stan_gamm4")
+  }
+  
   mc <- match.call(expand.dots = FALSE)
   family <- validate_family(family)
   glmod <- suppressWarnings(gamm4_to_glmer(formula, random, family, data, weights, 

--- a/R/stan_glm.R
+++ b/R/stan_glm.R
@@ -140,8 +140,10 @@ stan_glm <- function(formula, family = gaussian(), data, weights, subset,
   algorithm <- match.arg(algorithm)
   family <- validate_family(family)
   validate_glm_formula(formula)
-  if (missing(data)) 
+  if (missing(data)) {
+    warn_data_arg_missing("stan_glm")
     data <- environment(formula)
+  }
   call <- match.call(expand.dots = TRUE)
   mf <- match.call(expand.dots = FALSE)
   m <- match(c("formula", "data", "subset", "weights", "na.action", "offset"), 

--- a/R/stan_glmer.R
+++ b/R/stan_glmer.R
@@ -86,6 +86,9 @@ stan_glmer <- function(formula, data = NULL, family = gaussian,
                        algorithm = c("sampling", "meanfield", "fullrank"), 
                        adapt_delta = NULL, QR = FALSE, sparse = FALSE) {
   
+  if (missing(data)) 
+    warn_data_arg_missing("stan_glmer")
+  
   call <- match.call(expand.dots = TRUE)
   mc <- match.call(expand.dots = FALSE)
   family <- validate_family(family)

--- a/R/stan_lm.R
+++ b/R/stan_lm.R
@@ -116,6 +116,9 @@ stan_lm <- function(formula, data, subset, weights, na.action,
                     algorithm = c("sampling", "meanfield", "fullrank"), 
                     adapt_delta = NULL) {
   
+  if (missing(data)) 
+    warn_data_arg_missing("stan_lm")
+  
   algorithm <- match.arg(algorithm)
   validate_glm_formula(formula)
   call <- match.call(expand.dots = TRUE)

--- a/R/stan_polr.R
+++ b/R/stan_polr.R
@@ -130,6 +130,9 @@ stan_polr <- function(formula, data, weights, ..., subset,
                       algorithm = c("sampling", "meanfield", "fullrank"),
                       adapt_delta = NULL) {
 
+  if (missing(data)) 
+    warn_data_arg_missing("stan_polr")
+  
   algorithm <- match.arg(algorithm)
   call <- match.call(expand.dots = TRUE)
   m <- match.call(expand.dots = FALSE)

--- a/man-roxygen/args-formula-data-subset.R
+++ b/man-roxygen/args-formula-data-subset.R
@@ -1,1 +1,2 @@
-#' @param formula,data,subset Same as \code{\link[<%= pkg %>]{<%= pkgfun %>}}.
+#' @param formula,data,subset Same as \code{\link[<%= pkg %>]{<%= pkgfun %>}}
+#' except \code{data} can't be omitted.

--- a/man-roxygen/args-formula-data-subset.R
+++ b/man-roxygen/args-formula-data-subset.R
@@ -1,2 +1,5 @@
-#' @param formula,data,subset Same as \code{\link[<%= pkg %>]{<%= pkgfun %>}}
-#' except \code{data} can't be omitted.
+#' @param formula,data,subset Same as \code{\link[<%= pkg %>]{<%= pkgfun %>}}. 
+#'   However, \strong{we strongly advise against omitting the \code{data}
+#'   argument}. Unless \code{data} is specified (and is a data frame) many
+#'   post-estimation functions (including \code{update}, \code{loo},
+#'   \code{kfold}) are not guaranteed to work properly.


### PR DESCRIPTION
This PR introduces a deprecation warning if the `data` argument is omitted when fitting a model. We should do at least one release with the warning before we change the warning to an error. 