### PR TITLE
Warning if no data arg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,4 +56,4 @@ LazyData: true
 NeedsCompilation: yes
 URL: https://groups.google.com/forum/#!forum/stan-users, http://mc-stan.org/
 BugReports: https://github.com/stan-dev/rstanarm/issues
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/R/loo.R
+++ b/R/loo.R
@@ -19,9 +19,11 @@
 #' 
 #' For models fit using MCMC, compute approximate leave-one-out cross-validation
 #' (LOO) or, less preferably, the Widely Applicable Information Criterion (WAIC)
-#' using the \pkg{\link[=loo-package]{loo}} package. Exact \eqn{K}-fold
+#' using the \pkg{\link[=loo-package]{loo}} package. Exact \eqn{K}-fold 
 #' cross-validation is also available. Compare two or more models using the 
-#' \code{compare_models} function.
+#' \code{compare_models} function. \strong{Note:} these functions are not
+#' guaranteed to work properly unless the \code{data} argument was specified 
+#' when the model was fit.
 #' 
 #' @aliases loo waic
 #'

--- a/R/misc.R
+++ b/R/misc.R
@@ -684,3 +684,19 @@ check_stanfit <- function(x) {
   }
   return(TRUE)
 }
+
+# Throw a deprecation warning if 'data' argument to modeling function is missing
+# @param fun The name of a function
+warn_data_arg_missing <- function(fun) {
+  warning("Omitting the 'data' argument to ", fun, " is deprecated ",
+          "and will not be allowed in the next release of rstanarm.", 
+          call. = FALSE)
+}
+
+# Throw an error if 'data' argument to modeling function is missing
+# @param fun The name of a function
+stop_data_arg_missing <- function(fun) {
+  stop("The 'data' argument is required for ", fun, 
+       call. = FALSE)
+}
+

--- a/R/misc.R
+++ b/R/misc.R
@@ -685,14 +685,35 @@ check_stanfit <- function(x) {
   return(TRUE)
 }
 
+
+# Validate data argument
+#
+# Make sure that, if specified, data is a data frame.
+# 
+# @param data User's data argument
+# @param if_missing Object to return if data is missing/null
+# @return If no error is thrown, data itself is returned if not missing/null, 
+#   otherwise if_missing is returned.
+# 
+validate_data <- function(data, if_missing = NULL) {
+  if (missing(data) || is.null(data)) {
+    warn_data_arg_missing()
+    return(if_missing)
+  }
+  if (!is.data.frame(data))
+    stop("'data' must be a data frame.", call. = FALSE)
+  
+  return(data)
+}
+
 # Throw a warning if 'data' argument to modeling function is missing
-# @param fun The name of a function
-warn_data_arg_missing <- function(fun) {
+warn_data_arg_missing <- function() {
   warning(
-    "Omitting the 'data' argument to ", fun, " is not recommended ",
-    "and may not be allowed in the future versions of rstanarm. ", 
+    "Omitting the 'data' argument is not recommended ",
+    "and may not be allowed in future versions of rstanarm. ", 
     "Some post-estimation functions (in particular 'update', 'loo', 'kfold') ", 
     "are not guaranteed to work properly unless 'data' is specified as a data frame.",
-    call. = FALSE)
+    call. = FALSE
+  )
 }
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -685,18 +685,14 @@ check_stanfit <- function(x) {
   return(TRUE)
 }
 
-# Throw a deprecation warning if 'data' argument to modeling function is missing
+# Throw a warning if 'data' argument to modeling function is missing
 # @param fun The name of a function
 warn_data_arg_missing <- function(fun) {
-  warning("Omitting the 'data' argument to ", fun, " is deprecated ",
-          "and will not be allowed in the next release of rstanarm.", 
-          call. = FALSE)
-}
-
-# Throw an error if 'data' argument to modeling function is missing
-# @param fun The name of a function
-stop_data_arg_missing <- function(fun) {
-  stop("The 'data' argument is required for ", fun, 
-       call. = FALSE)
+  warning(
+    "Omitting the 'data' argument to ", fun, " is not recommended ",
+    "and may not be allowed in the future versions of rstanarm. ", 
+    "Some post-estimation functions (in particular 'update', 'loo', 'kfold') ", 
+    "are not guaranteed to work properly unless 'data' is specified as a data frame.",
+    call. = FALSE)
 }
 

--- a/R/stan_aov.R
+++ b/R/stan_aov.R
@@ -34,9 +34,7 @@ stan_aov <- function(formula, data, projections = FALSE,
                      prior_PD = FALSE, 
                      algorithm = c("sampling", "meanfield", "fullrank"), 
                      adapt_delta = NULL) {
-    if (missing(data)) 
-      warn_data_arg_missing("stan_aov")
-  
+
     # parse like aov() does
     Terms <- if (missing(data)) 
       terms(formula, "Error") else terms(formula, "Error", data = data)

--- a/R/stan_aov.R
+++ b/R/stan_aov.R
@@ -28,14 +28,17 @@
 #'          prior = R2(0.5), seed = 12345) 
 #' }
 #'             
-stan_aov <- function(formula, data = NULL, projections = FALSE,
+stan_aov <- function(formula, data, projections = FALSE,
                      contrasts = NULL, ...,
                      prior = R2(stop("'location' must be specified")), 
                      prior_PD = FALSE, 
                      algorithm = c("sampling", "meanfield", "fullrank"), 
                      adapt_delta = NULL) {
+    if (missing(data)) 
+      warn_data_arg_missing("stan_aov")
+  
     # parse like aov() does
-    Terms <- if(missing(data)) 
+    Terms <- if (missing(data)) 
       terms(formula, "Error") else terms(formula, "Error", data = data)
     indError <- attr(Terms, "specials")$Error
     ## NB: this is only used for n > 1, so singular form makes no sense

--- a/R/stan_betareg.R
+++ b/R/stan_betareg.R
@@ -123,6 +123,10 @@ stan_betareg <-
            algorithm = c("sampling", "optimizing", "meanfield", "fullrank"),
            adapt_delta = NULL,
            QR = FALSE) {
+    
+    if (missing(data)) 
+      warn_data_arg_missing("stan_betareg")
+    
     if (!requireNamespace("betareg", quietly = TRUE))
       stop("Please install the betareg package before using 'stan_betareg'.")
     

--- a/R/stan_betareg.R
+++ b/R/stan_betareg.R
@@ -124,12 +124,10 @@ stan_betareg <-
            adapt_delta = NULL,
            QR = FALSE) {
     
-    if (missing(data)) 
-      warn_data_arg_missing("stan_betareg")
-    
     if (!requireNamespace("betareg", quietly = TRUE))
       stop("Please install the betareg package before using 'stan_betareg'.")
     
+    data <- validate_data(data, if_missing = environment(formula))
     mc <- match.call(expand.dots = FALSE)
     mc$model <- mc$y <- mc$x <- TRUE
     

--- a/R/stan_gamm4.R
+++ b/R/stan_gamm4.R
@@ -35,7 +35,7 @@
 #' @template args-sparse
 #' 
 #' @param formula,random,family,data,knots,drop.unused.levels Same as for 
-#'   \code{\link[gamm4]{gamm4}}.
+#'   \code{\link[gamm4]{gamm4}} except \code{data} can't be omitted.
 #' @param subset,weights,na.action Same as \code{\link[stats]{glm}}, 
 #'   but rarely specified.
 #' @param ... Further arguments passed to \code{\link[rstan]{sampling}} (e.g. 
@@ -110,7 +110,7 @@
 #' }
 #' 
 #' @importFrom lme4 getME
-stan_gamm4 <- function(formula, random = NULL, family = gaussian(), data = list(), 
+stan_gamm4 <- function(formula, random = NULL, family = gaussian(), data, 
                        weights = NULL, subset = NULL, na.action, knots = NULL, 
                        drop.unused.levels = TRUE, ..., 
                        prior = normal(), prior_intercept = normal(),
@@ -119,6 +119,11 @@ stan_gamm4 <- function(formula, random = NULL, family = gaussian(), data = list(
                        algorithm = c("sampling", "meanfield", "fullrank"), 
                        adapt_delta = NULL, QR = FALSE, sparse = FALSE) {
 
+  if (missing(data)) {
+    data <- list()
+    warn_data_arg_missing("stan_gamm4")
+  }
+  
   mc <- match.call(expand.dots = FALSE)
   family <- validate_family(family)
   glmod <- suppressWarnings(gamm4_to_glmer(formula, random, family, data, weights, 

--- a/R/stan_gamm4.R
+++ b/R/stan_gamm4.R
@@ -35,7 +35,10 @@
 #' @template args-sparse
 #' 
 #' @param formula,random,family,data,knots,drop.unused.levels Same as for 
-#'   \code{\link[gamm4]{gamm4}} except \code{data} can't be omitted.
+#'   \code{\link[gamm4]{gamm4}}. \strong{We strongly advise against
+#'   omitting the \code{data} argument}. Unless \code{data} is specified (and is
+#'   a data frame) many post-estimation functions (including \code{update},
+#'   \code{loo}, \code{kfold}) are not guaranteed to work properly.
 #' @param subset,weights,na.action Same as \code{\link[stats]{glm}}, 
 #'   but rarely specified.
 #' @param ... Further arguments passed to \code{\link[rstan]{sampling}} (e.g. 
@@ -119,12 +122,8 @@ stan_gamm4 <- function(formula, random = NULL, family = gaussian(), data,
                        algorithm = c("sampling", "meanfield", "fullrank"), 
                        adapt_delta = NULL, QR = FALSE, sparse = FALSE) {
 
-  if (missing(data)) {
-    data <- list()
-    warn_data_arg_missing("stan_gamm4")
-  }
-  
   mc <- match.call(expand.dots = FALSE)
+  data <- validate_data(data, if_missing = list())
   family <- validate_family(family)
   glmod <- suppressWarnings(gamm4_to_glmer(formula, random, family, data, weights, 
                                            subset, na.action, knots, drop.unused.levels))

--- a/R/stan_glm.R
+++ b/R/stan_glm.R
@@ -140,8 +140,10 @@ stan_glm <- function(formula, family = gaussian(), data, weights, subset,
   algorithm <- match.arg(algorithm)
   family <- validate_family(family)
   validate_glm_formula(formula)
-  if (missing(data)) 
+  if (missing(data)) {
+    warn_data_arg_missing("stan_glm")
     data <- environment(formula)
+  }
   call <- match.call(expand.dots = TRUE)
   mf <- match.call(expand.dots = FALSE)
   m <- match(c("formula", "data", "subset", "weights", "na.action", "offset"), 

--- a/R/stan_glm.R
+++ b/R/stan_glm.R
@@ -140,10 +140,8 @@ stan_glm <- function(formula, family = gaussian(), data, weights, subset,
   algorithm <- match.arg(algorithm)
   family <- validate_family(family)
   validate_glm_formula(formula)
-  if (missing(data)) {
-    warn_data_arg_missing("stan_glm")
-    data <- environment(formula)
-  }
+  data <- validate_data(data, if_missing = environment(formula))
+  
   call <- match.call(expand.dots = TRUE)
   mf <- match.call(expand.dots = FALSE)
   m <- match(c("formula", "data", "subset", "weights", "na.action", "offset"), 

--- a/R/stan_glmer.R
+++ b/R/stan_glmer.R
@@ -36,7 +36,11 @@
 #' @template args-sparse
 #' @template reference-gelman-hill
 #' 
-#' @param formula,data,family Same as for \code{\link[lme4]{glmer}}.
+#' @param formula,data,family Same as for \code{\link[lme4]{glmer}}. \strong{We
+#'   strongly advise against omitting the \code{data} argument}. Unless
+#'   \code{data} is specified (and is a data frame) many post-estimation
+#'   functions (including \code{update}, \code{loo}, \code{kfold}) are not
+#'   guaranteed to work properly.
 #' @param subset,weights,offset Same as \code{\link[stats]{glm}}.
 #' @param na.action,contrasts Same as \code{\link[stats]{glm}}, but rarely 
 #'   specified.
@@ -86,11 +90,9 @@ stan_glmer <- function(formula, data = NULL, family = gaussian,
                        algorithm = c("sampling", "meanfield", "fullrank"), 
                        adapt_delta = NULL, QR = FALSE, sparse = FALSE) {
   
-  if (missing(data)) 
-    warn_data_arg_missing("stan_glmer")
-  
   call <- match.call(expand.dots = TRUE)
   mc <- match.call(expand.dots = FALSE)
+  data <- validate_data(data) #, if_missing = environment(formula))
   family <- validate_family(family)
   mc[[1]] <- quote(lme4::glFormula)
   mc$control <- make_glmerControl()

--- a/R/stan_glmer.R
+++ b/R/stan_glmer.R
@@ -86,6 +86,9 @@ stan_glmer <- function(formula, data = NULL, family = gaussian,
                        algorithm = c("sampling", "meanfield", "fullrank"), 
                        adapt_delta = NULL, QR = FALSE, sparse = FALSE) {
   
+  if (missing(data)) 
+    warn_data_arg_missing("stan_glmer")
+  
   call <- match.call(expand.dots = TRUE)
   mc <- match.call(expand.dots = FALSE)
   family <- validate_family(family)

--- a/R/stan_lm.R
+++ b/R/stan_lm.R
@@ -116,11 +116,9 @@ stan_lm <- function(formula, data, subset, weights, na.action,
                     algorithm = c("sampling", "meanfield", "fullrank"), 
                     adapt_delta = NULL) {
   
-  if (missing(data)) 
-    warn_data_arg_missing("stan_lm")
-  
   algorithm <- match.arg(algorithm)
   validate_glm_formula(formula)
+  validate_data(data)
   call <- match.call(expand.dots = TRUE)
   mf <- match.call(expand.dots = FALSE)
   mf[[1L]] <- as.name("lm")

--- a/R/stan_lm.R
+++ b/R/stan_lm.R
@@ -116,6 +116,9 @@ stan_lm <- function(formula, data, subset, weights, na.action,
                     algorithm = c("sampling", "meanfield", "fullrank"), 
                     adapt_delta = NULL) {
   
+  if (missing(data)) 
+    warn_data_arg_missing("stan_lm")
+  
   algorithm <- match.arg(algorithm)
   validate_glm_formula(formula)
   call <- match.call(expand.dots = TRUE)

--- a/R/stan_polr.R
+++ b/R/stan_polr.R
@@ -130,6 +130,9 @@ stan_polr <- function(formula, data, weights, ..., subset,
                       algorithm = c("sampling", "meanfield", "fullrank"),
                       adapt_delta = NULL) {
 
+  if (missing(data)) 
+    warn_data_arg_missing("stan_polr")
+  
   algorithm <- match.arg(algorithm)
   call <- match.call(expand.dots = TRUE)
   m <- match.call(expand.dots = FALSE)

--- a/R/stan_polr.R
+++ b/R/stan_polr.R
@@ -130,9 +130,7 @@ stan_polr <- function(formula, data, weights, ..., subset,
                       algorithm = c("sampling", "meanfield", "fullrank"),
                       adapt_delta = NULL) {
 
-  if (missing(data)) 
-    warn_data_arg_missing("stan_polr")
-  
+  data <- validate_data(data)
   algorithm <- match.arg(algorithm)
   call <- match.call(expand.dots = TRUE)
   m <- match.call(expand.dots = FALSE)

--- a/man-roxygen/args-formula-data-subset.R
+++ b/man-roxygen/args-formula-data-subset.R
@@ -1,1 +1,2 @@
-#' @param formula,data,subset Same as \code{\link[<%= pkg %>]{<%= pkgfun %>}}.
+#' @param formula,data,subset Same as \code{\link[<%= pkg %>]{<%= pkgfun %>}}
+#' except \code{data} can't be omitted.

--- a/man-roxygen/args-formula-data-subset.R
+++ b/man-roxygen/args-formula-data-subset.R
@@ -1,2 +1,5 @@
-#' @param formula,data,subset Same as \code{\link[<%= pkg %>]{<%= pkgfun %>}}
-#' except \code{data} can't be omitted.
+#' @param formula,data,subset Same as \code{\link[<%= pkg %>]{<%= pkgfun %>}}. 
+#'   However, \strong{we strongly advise against omitting the \code{data}
+#'   argument}. Unless \code{data} is specified (and is a data frame) many
+#'   post-estimation functions (including \code{update}, \code{loo},
+#'   \code{kfold}) are not guaranteed to work properly.

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -157,6 +157,13 @@ test_that("validate_glm_formula works", {
   expect_error(validate_glm_formula(mpg ~ (1|cyl/gear)), "not allowed")
 })
 
+test_that("validate_data works", {
+  expect_error(validate_data(list(1)), 
+               "'data' must be a data frame")
+  expect_warning(d <- validate_data(if_missing = 3), 
+                 "Omitting the 'data' argument is not recommended")
+  expect_equal(d, 3)
+})
 
 test_that("array1D_check works", {
   array1D_check <- rstanarm:::array1D_check


### PR DESCRIPTION
This PR introduces a warning if the `data` argument is not specified when fitting a model and an error if it is specified but is not a data frame.

The doc has also been updated with a warning about not specifying the data argument.

Closes #162