### PR TITLE
Bugfix issue169 call

### DIFF
--- a/R/print-and-summary.R
+++ b/R/print-and-summary.R
@@ -65,7 +65,11 @@
 #' @seealso \code{\link{summary.stanreg}}, \code{\link{stanreg-methods}}
 #' 
 print.stanreg <- function(x, digits = 1, ...) {
-  print(x$call)
+  cat(x$modeling_function)
+  cat("\n family: ", family_plus_link(x))
+  cat("\n formula:", formula_string(formula(x)))
+  
+  cat("\n------\n")
   cat("\nEstimates:\n")
   
   mer <- is.mer(x)
@@ -252,24 +256,12 @@ summary.stanreg <- function(object, pars = NULL, regex_pars = NULL,
     out <- object$stan_summary[mark, , drop=FALSE]
   }
   
-  fam <- family(object)
-  if (is.character(fam)) {
-    stopifnot(identical(fam, object$method))
-    fam <- paste0("ordered (", fam, ")")
-  } else if (inherits(object, "betareg")) {
-    fam <- paste0("beta (", 
-                  object$family$link, 
-                  ", link.phi=", 
-                  object$family_phi$link, 
-                  ")")
-  } else {
-    fam <- paste0(fam$family, " (", fam$link, ")") 
-  }
-  
   structure(out, 
             call = object$call, 
             algorithm = object$algorithm,
-            family = fam,
+            modeling_function = object$modeling_function,
+            family = family_plus_link(object),
+            formula = formula(object),
             posterior_sample_size = posterior_sample_size(object),
             nobs = nobs(object),
             ngrps = if (mer) ngrps(object) else NULL,
@@ -286,14 +278,17 @@ summary.stanreg <- function(object, pars = NULL, regex_pars = NULL,
 print.summary.stanreg <- function(x, digits = max(1, attr(x, "print.digits")), 
                                   ...) {
   atts <- attributes(x)
-  print(atts$call)
-  cat("\nFamily:", atts$family)
-  cat("\nAlgorithm:", atts$algorithm)
+  cat("\nModel Info:\n")
+  cat("\n function: ", atts$modeling_function)
+  cat("\n family:   ", atts$family)
+  cat("\n formula:  ", formula_string(atts$formula))
+  cat("\n algorithm:", atts$algorithm)
+  cat("\n priors:   ", "see help('prior_summary')")
   if (!is.null(atts$posterior_sample_size) && atts$algorithm == "sampling")
-    cat("\nPosterior sample size:", atts$posterior_sample_size)
-  cat("\nObservations:", atts$nobs)
+    cat("\n sample:   ", atts$posterior_sample_size, "(posterior sample size)")
+  cat("\n num obs:  ", atts$nobs)
   if (!is.null(atts$ngrps))
-    cat("\nGroups:", paste(names(atts$ngrps), unname(atts$ngrps), 
+    cat("\n groups:   ", paste0(names(atts$ngrps), " (", unname(atts$ngrps), ")",
                            collapse = ", "))
   
   cat("\n\nEstimates:\n")
@@ -359,5 +354,33 @@ allow_special_parnames <- function(object, pars) {
   }
   pars2 <- c(pars2, setdiff(pars, c("alpha", "beta", "varying")))
   pars2[!is.na(pars2)]
+}
+
+# Family name with link in parenthesis 
+# @param x stanreg object
+family_plus_link <- function(x) {
+  fam <- family(x)
+  if (is.character(fam)) {
+    stopifnot(identical(fam, x$method))
+    fam <- paste0("ordered [", fam, "]")
+  } else if (inherits(x, "betareg")) {
+    fam <- paste0("beta [",
+                  x$family$link,
+                  ", link.phi=",
+                  x$family_phi$link,
+                  "]")
+  } else {
+    fam <- paste0(fam$family, " [", fam$link, "]")
+  }
+  return(fam)
+}
+
+# @param formula formula object
+formula_string <- function(formula, break_and_indent = TRUE) {
+  coll <- if (break_and_indent) "--MARK--" else " "
+  char <- gsub("\\s+", " ", paste(deparse(formula), collapse = coll))
+  if (!break_and_indent)
+    return(char)
+  gsub("--MARK--", "\n\t  ", char, fixed = TRUE)
 }
 

--- a/R/rstanarm-package.R
+++ b/R/rstanarm-package.R
@@ -39,12 +39,12 @@
 #'    \emph{Stan Development Team}
 #' }
 #' 
-#' An appendage to the \pkg{rstan} package that enables some of the most common
-#' applied regression models to be estimated using Markov Chain Monte Carlo,
-#' variational approximations to the posterior distribution, or optimization.
-#' The \pkg{rstanarm} package allows these models to be specified using the
-#' customary R modeling syntax (e.g., like that of \code{\link[stats]{glm}} with
-#' a \code{formula} and a \code{data.frame}).
+#' The \pkg{rstanarm} package is an appendage to the \pkg{rstan} package that
+#' enables many of the most common applied regression models to be estimated
+#' using Markov Chain Monte Carlo, variational approximations to the posterior
+#' distribution, or optimization. The \pkg{rstanarm} package allows these models
+#' to be specified using the customary R modeling syntax (e.g., like that of
+#' \code{\link[stats]{glm}} with a \code{formula} and a \code{data.frame}).
 #' 
 #' The set of models supported by \pkg{rstanarm} is large (and will continue to
 #' grow), but also limited enough so that it is possible to integrate them 

--- a/R/stan_aov.R
+++ b/R/stan_aov.R
@@ -69,8 +69,10 @@ stan_aov <- function(formula, data = NULL, projections = FALSE,
         if (projections) 
           fit$projections <- proj(fit)
         fit$call <- Call
+        fit$modeling_function <- "stan_aov"
         return(fit)
     } else { # nocov start
+      
         stop("Error terms not supported yet")
         if(pmatch("weights", names(match.call()), 0L))
             stop("weights are not supported in a multistratum aov() fit")

--- a/R/stan_betareg.R
+++ b/R/stan_betareg.R
@@ -170,7 +170,8 @@ stan_betareg <-
             x = X, y = Y, z = Z %ORifNULL% model.matrix(y ~ 1),
             family = beta_fam(link), family_phi = beta_phi_fam(link_phi),
             formula, model = mf, terms = mt, call = match.call(),
-            na.action = attr(mf, "na.action"), contrasts = attr(X, "contrasts"))
+            na.action = attr(mf, "na.action"), contrasts = attr(X, "contrasts"), 
+            modeling_function = "stan_betareg")
     out <- stanreg(fit)
     out$xlevels <- lapply(mf[,-1], FUN = function(x) {
       xlev <- if (is.factor(x) || is.character(x)) levels(x) else NULL

--- a/R/stan_gamm4.R
+++ b/R/stan_gamm4.R
@@ -195,7 +195,8 @@ stan_gamm4 <- function(formula, random = NULL, family = gaussian(), data = list(
   fit <- nlist(stanfit, family, formula, offset, weights, 
                x = XZ, y = y, data, terms = NULL, model = NULL, 
                call = match.call(expand.dots = TRUE),
-               algorithm, glmod = glmod)
+               algorithm, glmod = glmod, 
+               modeling_function = "stan_gamm4")
   out <- stanreg(fit)
   class(out) <- c(class(out), "gamm4", "lmerMod")
   return(out)

--- a/R/stan_glm.R
+++ b/R/stan_glm.R
@@ -176,7 +176,8 @@ stan_glm <- function(formula, family = gaussian(), data, weights, subset,
   fit <- nlist(stanfit, algorithm, family, formula, data, offset, weights,
                x = X, y = Y, model = mf,  terms = mt, call, 
                na.action = attr(mf, "na.action"), 
-               contrasts = attr(X, "contrasts"))
+               contrasts = attr(X, "contrasts"), 
+               modeling_function = "stan_glm")
   out <- stanreg(fit)
   out$xlevels <- .getXlevels(mt, mf)
   if (!x) 
@@ -224,5 +225,6 @@ stan_glm.nb <- function(formula,
   mc$family <- neg_binomial_2(link = link)
   out <- eval(mc, parent.frame())
   out$call <- call
+  out$modeling_function <- "stan_glm.nb"
   return(out)
 }

--- a/R/stan_glmer.R
+++ b/R/stan_glmer.R
@@ -127,7 +127,8 @@ stan_glmer <- function(formula, data = NULL, family = gaussian,
   fit <- nlist(stanfit, family, formula, offset, weights, 
                x = if (getRversion() < "3.2.0") cBind(X, Z) else cbind2(X, Z), 
                y = y, data, call, terms = NULL, model = NULL, 
-               na.action, contrasts, algorithm, glmod)
+               na.action, contrasts, algorithm, glmod, 
+               modeling_function = "stan_glmer")
   out <- stanreg(fit)
   class(out) <- c(class(out), "lmerMod")
   
@@ -163,6 +164,7 @@ stan_lmer <- function(formula,
   mc$family <- "gaussian"
   out <- eval(mc, parent.frame())
   out$call <- call
+  out$modeling_function <- "stan_lmer"
   return(out)
 }
 
@@ -199,5 +201,6 @@ stan_glmer.nb <- function(formula,
   mc$family <- neg_binomial_2(link = link)
   out <- eval(mc, parent.frame())
   out$call <- call
+  out$modeling_function <- "stan_glmer.nb"
   return(out)
 }

--- a/R/stan_lm.R
+++ b/R/stan_lm.R
@@ -144,7 +144,8 @@ stan_lm <- function(formula, data, subset, weights, na.action,
                algorithm, call, terms = mt,
                model = if (model) modelframe else NULL,
                na.action = attr(modelframe, "na.action"),
-               contrasts = attr(X, "contrasts"))
+               contrasts = attr(X, "contrasts"), 
+               modeling_function = "stan_lm")
   out <- stanreg(fit)
   out$xlevels <- .getXlevels(mt, modelframe)
   if (!x) 

--- a/R/stan_polr.R
+++ b/R/stan_polr.R
@@ -188,7 +188,8 @@ stan_polr <- function(formula, data, weights, ..., subset,
                  x = cbind("(Intercept)" = 1, x), y = as.integer(y == lev[2]),
                  data, call, terms = Terms, model = m,
                  algorithm, na.action = attr(m, "na.action"),
-                 contrasts = attr(x, "contrasts"))
+                 contrasts = attr(x, "contrasts"), 
+                 modeling_function = "stan_polr")
     out <- stanreg(fit)
     if (!model)
       out$model <- NULL
@@ -239,7 +240,8 @@ stan_polr <- function(formula, data, weights, ..., subset,
                call, formula, terms = Terms,
                prior.info = attr(stanfit, "prior.info"),
                algorithm, stan_summary, stanfit, 
-               rstan_version = utils::packageVersion("rstan"))
+               rstan_version = utils::packageVersion("rstan"), 
+               modeling_function = "stan_polr")
   structure(out, class = c("stanreg", "polr"))
 }
 

--- a/R/stanreg.R
+++ b/R/stanreg.R
@@ -120,14 +120,18 @@ stanreg <- function(object) {
     prior.weights = object$weights, 
     contrasts = object$contrasts, 
     na.action = object$na.action,
-    call = object$call, 
     formula = object$formula, 
     terms = object$terms,
     prior.info = attr(stanfit, "prior.info"),
     algorithm = object$algorithm,
     stan_summary,  
     stanfit = if (opt) stanfit$stanfit else stanfit,
-    rstan_version = utils::packageVersion("rstan")
+    rstan_version = utils::packageVersion("rstan"),
+    call = object$call, 
+    # sometimes 'call' is no good (e.g. if using do.call(stan_glm, args)) so
+    # also include the name of the modeling function (for use when printing,
+    # etc.)
+    modeling_function = object$modeling_function
   )
 
   if (opt) 


### PR DESCRIPTION
Closes #169 

As reported in #169 the output from `print.stanreg` and `summary.stanreg` is a mess when a model is fit using `do.call`. This PR changes the printed output from the `print.stanreg` and `summary.stanreg` methods so that it doesn't display the actual `call` object at the top but rather just some of the info that would be included in call. 

@bgoodri @imadmali Anything you think should included beyond what I have or anything that should be removed? (See example below.)

-----

For example, now these two ways of fitting the same model
```r
fit <- stan_glmer(mpg ~ wt + (1 + wt|cyl), data = mtcars)
fit <- do.call(stan_glmer, args = list(formula = mpg ~ wt + (1 + wt|cyl), data = mtcars))
```
will result in the same output from `print` and `summary`.

The beginning of the output from `print` is now

```r
print(fit)
```
```
stan_glmer
 family:  gaussian [identity]
 formula: mpg ~ wt + (1 + wt | cyl)
------

Estimates:
            Median MAD_SD
(Intercept) -58.3   53.1 
wt           18.9   16.5 
sigma        39.9   13.1 
...
```

And the beginning of the new output from `summary` is:
 
```r
summary(fit)
```
```
Model Info:

 function:  stan_glmer
 family:    gaussian [identity]
 formula:   mpg ~ wt + (1 + wt | cyl)
 algorithm: sampling
 priors:    see help('prior_summary')
 sample:    4000 (posterior sample size)
 num obs:   32
 groups:    cyl (3)

Estimates:
                                     mean   sd     2.5%   25%    50%    75%    97.5%
(Intercept)                         -47.8   34.0  -90.5  -58.3  -58.3  -14.1  -14.1 
wt                                   15.6   10.5    5.2    5.2   18.9   18.9   28.9 
b[(Intercept) cyl:4]                 -0.3    0.2   -0.5   -0.5   -0.2   -0.1   -0.1 
b[wt cyl:4]                          -0.2    0.1   -0.2   -0.2   -0.1   -0.1   -0.1 
b[(Intercept) cyl:6]                  0.5    0.3    0.3    0.3    0.3    0.8    0.8 
...
```

