### PR TITLE
cleanup-betareg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 r: devel
 cache: packages
 
-r_build_args: --no-build-vignettes
-r_check_args: --no-build-vignettes
+latex: false
+r_build_args: '--no-build-vignettes'
+r_check_args: '--ignore-vignettes --no-examples'
 
 r_github_packages:
   - jimhester/covr
@@ -25,7 +26,7 @@ before_install:
 script: 
   - |
     travis_wait R CMD build .
-    travis_wait 60 R CMD check rstanarm*tar.gz
+    travis_wait 40 R CMD check rstanarm*tar.gz
 
 after_script:
   - tar -ztvf rstanarm_*.tar.gz

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,4 +58,4 @@ LazyData: true
 NeedsCompilation: yes
 URL: https://groups.google.com/forum/#!forum/stan-users, http://mc-stan.org/
 BugReports: https://github.com/stan-dev/rstanarm/issues
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,9 +17,10 @@ Authors@R: c(person("Jonah", "Gabry", email = "jsg2201@columbia.edu", role = "au
              person("William", "Venables", role = "cph", comment = "R/stan_polr.R"),
              person("Ben", "Goodrich", email = "benjamin.goodrich@columbia.edu", 
                     role = c("cre", "aut")))
-Description: Estimates pre-compiled regression models using the 'rstan' package, which provides
-    the R interface to the Stan C++ library for Bayesian estimation. Users specify models via the
-    customary R syntax with a formula and data.frame plus some additional arguments for priors.
+Description: Estimates pre-compiled regression models using the 'rstan' package,
+    which provides the R interface to the Stan C++ library for Bayesian estimation.
+    Users specify models via the customary R syntax with a formula and data.frame
+    plus some additional arguments for priors.
 License: GPL (>=3)
 Depends:
     R (>= 3.0.2),
@@ -57,4 +58,4 @@ LazyData: true
 NeedsCompilation: yes
 URL: https://groups.google.com/forum/#!forum/stan-users, http://mc-stan.org/
 BugReports: https://github.com/stan-dev/rstanarm/issues
-RoxygenNote: 6.0.1
+RoxygenNote: 5.0.1

--- a/exec/continuous.stan
+++ b/exec/continuous.stan
@@ -192,11 +192,8 @@ generated quantities {
     omega_int[1] = gamma_z[1] - dot_product(zbar, omega);  // adjust betareg intercept 
   }
   {
-    real nan_count; // for the beta_rng underflow issue
-    real yrep; // pick up value to test for the beta_rng underflow issue
     vector[N] eta_z;
     #include "make_eta.stan" // defines eta
-    nan_count = 0;
     if (t > 0) {
       #include "eta_add_Zb.stan"
     }
@@ -253,22 +250,9 @@ generated quantities {
     else if (family == 4 && link_phi > 0) {
       eta = linkinv_beta(eta, link);
       eta_z = linkinv_beta_z(eta_z, link_phi);
-      for (n in 1:N) {
-        yrep = beta_rng(eta[n] * eta_z[n], (1 - eta[n]) * eta_z[n]);
-          if (is_nan(yrep) == 1) {
-            mean_PPD = mean_PPD;
-            nan_count = nan_count + 1;
-          }
-          else if (is_nan(yrep) == 0) {
-            mean_PPD = mean_PPD + yrep; 
-          }
-      }
+      for (n in 1:N)
+        mean_PPD = mean_PPD + beta_rng(eta[n] * eta_z[n], (1 - eta[n]) * eta_z[n]);
     }
-    if (family == 4 && link_phi > 0) {
-      mean_PPD = mean_PPD / (N - nan_count);
-    }
-    else {
-      mean_PPD = mean_PPD / N;
-    }
+    mean_PPD = mean_PPD / N;
   }
 }

--- a/tests/testthat/test_methods.R
+++ b/tests/testthat/test_methods.R
@@ -594,8 +594,10 @@ test_that("print and summary methods ok for mcmc and vb", {
   expect_silent(d <- as.data.frame(s))
   expect_s3_class(s, "summary.stanreg")
   expect_output(print(s), "stan_glmer")
-  expect_output(print(s), paste("Posterior sample size:",
-                                rstanarm:::posterior_sample_size(example_model)))
+  expect_output(
+    print(s), 
+    paste(rstanarm:::posterior_sample_size(example_model)), "(posterior sample size)"
+  )
   expect_identical(attr(s, "algorithm"), "sampling")
   expect_identical(colnames(s), colnames(d))
   expect_identical(rownames(s), rownames(d))

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -492,8 +492,8 @@ test_that("validate_newdata works", {
 
 
 test_that("recommend_QR_for_vb produces the right message", {
-  expect_output(
-    recommend_QR_for_vb(), 
+  expect_message(
+    rstanarm:::recommend_QR_for_vb(),
     "Setting 'QR' to TRUE can often be helpful when using one of the variational inference algorithms"
   )
 })

--- a/tests/testthat/test_stan_betareg.R
+++ b/tests/testthat/test_stan_betareg.R
@@ -143,8 +143,8 @@ test_that("stan_betareg ok when modeling x and z (link.phi = 'identity')", {
     SW(fit <- stan_betareg(y ~ x | z, link = link1[i], link.phi = link2[2],
                            prior = NULL, prior_intercept = NULL,
                            prior_z = NULL, prior_intercept_z = NULL,
-                           data = dat, algorithm = "sampling", 
-                           chains = 2, iter = 300, seed = SEED))
+                           data = dat, algorithm = "optimizing", 
+                           seed = SEED))
     expect_stanreg(fit)
     val <- coef(fit)
     ans <- coef(betareg(y ~ x | z, link = link1[i], link.phi = link2[2], data = dat))
@@ -155,15 +155,14 @@ test_that("stan_betareg ok when modeling x and z (link.phi = 'identity')", {
 # sqrt link is unstable so only testing that the model runs. 
 test_that("stan_betareg ok when modeling x and z (link.phi = 'sqrt')", {
   for (i in 1:length(link1)) {  # FIXME!
-    N <- 300
+    N <- 1000
     dat <- data.frame(x = rnorm(N, 2, 1), z = rep(1, N))
     mu <- binomial(link = "logit")$linkinv(-0.8 + 0.5*dat$x)
     phi <- poisson(link = "sqrt")$linkinv(8 + 2*dat$z)
     dat$y <- rbeta(N, mu * phi, (1 - mu) * phi)
 
     SW(fit <- stan_betareg(y ~ x | 1, link = link1[i], link.phi = link2[3], 
-                           data = dat, algorithm = "sampling",
-                           chains = 1, iter = 1)) 
+                           data = dat, algorithm = "sampling", chains = 1, iter = 1)) 
     expect_stanreg(fit)
   }
 })


### PR DESCRIPTION
Cleaned up some of the code in `continuous.stan` and updated some of the tests so that they use `algorithm = "optimizing"` instead of `algorithm = "sampling"`. (Now the runtime for `devtools:tests()` is only ~5 min.)