### PR TITLE
stan_aov uses contrasts args correctly, corrected example

### DIFF
--- a/R/stan_aov.R
+++ b/R/stan_aov.R
@@ -24,8 +24,10 @@
 #'   on the fit.
 #' @examples
 #' \donttest{
-#' stan_aov(yield ~ block + N*P*K, data = npk, contrasts = "contr.poly",
+#' op <- options(contrasts = c("contr.helmert", "contr.poly"))
+#' stan_aov(yield ~ block + N*P*K, data = npk,
 #'          prior = R2(0.5), seed = 12345) 
+#' options(op)
 #' }
 #'             
 stan_aov <- function(formula, data, projections = FALSE,
@@ -57,7 +59,7 @@ stan_aov <- function(formula, data, projections = FALSE,
         ## no Error term
         fit <- eval(lmcall, parent.frame())
         fit$terms <- Terms
-        fit$qr <- qr(model.matrix(Terms, data = fit$data))
+        fit$qr <- qr(model.matrix(Terms, data = fit$data, contrasts.arg = contrasts))
         R <- qr.R(fit$qr)
         beta <- extract(fit$stanfit, pars = "beta", permuted = FALSE)
         pnames <- dimnames(beta)$parameters


### PR DESCRIPTION
This pull request removes a bug in `stan_aov` that prevents the correct use of the `contrast` argument and corrects the wrong use of `contrast` in the `stan_aov`  example.

First, the argument to `contrast` needs to be a `list` (as it is passed on to `model.matrix`). A string, as used in the current example, is simply ignored. See the following, where the first is the current example, the second does not use `contrast` and produces the same results.

```
m0 <- stan_aov(yield ~ block + N*P*K, data = npk, 
               contrasts = "contr.poly",
               prior = R2(0.5), seed = 12345) 
m1 <- stan_aov(yield ~ block + N*P*K, data = npk,
         prior = R2(0.5), seed = 12345) 
coef(m0)
# (Intercept)      block2      block3      block4      block5      block6 
#  52.8067806   2.3560570   4.6887685  -2.7458011  -2.5431397   1.6206793 
#          N1          P1          K1       N1:P1       N1:K1       P1:K1 
#   6.8903880   0.2415632  -1.4681392  -2.5408158  -3.2804039   0.5479966 
coef(m1)
# (Intercept)      block2      block3      block4      block5      block6 
#  52.8067806   2.3560570   4.6887685  -2.7458011  -2.5431397   1.6206793 
#          N1          P1          K1       N1:P1       N1:K1       P1:K1 
#   6.8903880   0.2415632  -1.4681392  -2.5408158  -3.2804039   0.5479966 
```

The bug is that `stan_aov` fails when passing `contrasts` in the correct manner:
```
m2 <- stan_aov(yield ~ block + N*P*K, data = npk, contrasts = list(block ="contr.poly"),
         prior = R2(0.5), seed = 12345) 
# Error in R[pnames, pnames, drop = FALSE] : subscript out of bounds

```

The reason for this is that `contrasts` is not passed to the `model.matrix` call inside `stan_aov` (line 60). When correcting this, it works as expected:

```
m3 <- stan_aov(yield ~ block + N*P*K, data = npk, contrasts = list(block ="contr.poly"),
         prior = R2(0.5), seed = 12345) 
coef(m3)
# (Intercept)     block.L     block.Q     block.C     block^4     block^5 
#  53.3399220  -1.6699295   0.0536834   5.3806826   1.1597300  -3.1255215 
#          N1          P1          K1       N1:P1       N1:K1       P1:K1 
#   6.8656239   0.3059468  -1.3284234  -2.6267374  -3.2694577   0.3849385
```

To use appropriate ANOVA contrasts in the example I have followed `?aov` and used the options (instead of making a long list with all four factors).

Can you please salso comment on whether you prefer bug reports and corrections like this or via the mailing list (as done earlier today from me with a different bug)?
