### PR TITLE
Have prior_aux default to exponential distribution

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,4 +59,4 @@ LazyData: true
 NeedsCompilation: yes
 URL: https://groups.google.com/forum/#!forum/stan-users, http://mc-stan.org/
 BugReports: https://github.com/stan-dev/rstanarm/issues
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/R/prior_summary.R
+++ b/R/prior_summary.R
@@ -242,7 +242,8 @@ used.sparse <- function(x) {
       }
   )
   if (!is.null(p$adjusted_scale))
-    cat("\n     **adjusted scale =", .f2(p$adjusted_scale))
+    cat("\n     **adjusted scale =", .f2(p$adjusted_scale), 
+        if (p$dist == "exponential") ("(adjusted rate = 1/adjusted scale)"))
 }
 .print_vector_prior <- function(p, txt = "Coefficients", formatters = list()) {
   stopifnot(length(formatters) == 2)

--- a/R/stan_betareg.R
+++ b/R/stan_betareg.R
@@ -115,7 +115,7 @@ stan_betareg <-
            prior_intercept = normal(),
            prior_z = normal(),
            prior_intercept_z = normal(),
-           prior_phi = cauchy(0, 5),
+           prior_phi = exponential(),
            prior_PD = FALSE,
            algorithm = c("sampling", "optimizing", "meanfield", "fullrank"),
            adapt_delta = NULL,

--- a/R/stan_betareg.fit.R
+++ b/R/stan_betareg.fit.R
@@ -19,22 +19,22 @@
 #' @export
 #' @param z For \code{stan_betareg.fit}, a regressor matrix for \code{phi}.
 #'   Defaults to an intercept only.
-stan_betareg.fit <- function(x, y, z = NULL, 
-                             weights = rep(1, NROW(x)), 
-                             offset = rep(0, NROW(x)),
-                             link = c("logit", "probit", "cloglog", 
-                                      "cauchit", "log", "loglog"), 
-                             link.phi = NULL, ...,
-                             prior = normal(), 
-                             prior_intercept = normal(),
-                             prior_z = normal(), 
-                             prior_intercept_z = normal(),
-                             prior_phi = cauchy(0, 5),
-                             prior_PD = FALSE, 
-                             algorithm = c("sampling", "optimizing", 
-                                           "meanfield", "fullrank"),
-                             adapt_delta = NULL, 
-                             QR = FALSE) {
+#'   
+stan_betareg.fit <- 
+  function(x, y, z = NULL, 
+           weights = rep(1, NROW(x)), 
+           offset = rep(0, NROW(x)),
+           link = c("logit", "probit", "cloglog", "cauchit", "log", "loglog"), 
+           link.phi = NULL, ...,
+           prior = normal(), 
+           prior_intercept = normal(),
+           prior_z = normal(), 
+           prior_intercept_z = normal(),
+           prior_phi = exponential(),
+           prior_PD = FALSE, 
+           algorithm = c("sampling", "optimizing", "meanfield", "fullrank"),
+           adapt_delta = NULL, 
+           QR = FALSE) {
   
   algorithm <- match.arg(algorithm)
   

--- a/R/stan_gamm4.R
+++ b/R/stan_gamm4.R
@@ -111,16 +111,28 @@
 #' plot_nonlinear(br, smooths = "s(x0)", alpha = 2/3)
 #' }
 #' 
-stan_gamm4 <- function(formula, random = NULL, family = gaussian(), data, 
-                       weights = NULL, subset = NULL, na.action, knots = NULL, 
-                       drop.unused.levels = TRUE, ..., 
-                       prior = normal(), prior_intercept = normal(),
-                       prior_smooth = exponential(autoscale = FALSE), 
-                       prior_aux = cauchy(0, 5),
-                       prior_covariance = decov(), prior_PD = FALSE, 
-                       algorithm = c("sampling", "meanfield", "fullrank"), 
-                       adapt_delta = NULL, QR = FALSE, sparse = FALSE) {
-
+stan_gamm4 <-
+  function(formula,
+           random = NULL,
+           family = gaussian(),
+           data,
+           weights = NULL,
+           subset = NULL,
+           na.action,
+           knots = NULL,
+           drop.unused.levels = TRUE,
+           ...,
+           prior = normal(),
+           prior_intercept = normal(),
+           prior_smooth = exponential(autoscale = FALSE),
+           prior_aux = exponential(),
+           prior_covariance = decov(),
+           prior_PD = FALSE,
+           algorithm = c("sampling", "meanfield", "fullrank"),
+           adapt_delta = NULL,
+           QR = FALSE,
+           sparse = FALSE) {
+    
   data <- validate_data(data, if_missing = list())
   family <- validate_family(family)
   

--- a/R/stan_glm.R
+++ b/R/stan_glm.R
@@ -136,16 +136,28 @@
 #' plot(fit6, "areas", pars = "reciprocal_dispersion", prob = 0.8)
 #' }
 #'
-stan_glm <- function(formula, family = gaussian(), data, weights, subset,
-                    na.action = NULL, offset = NULL, model = TRUE, 
-                    x = FALSE, y = TRUE, contrasts = NULL, ..., 
-                    prior = normal(), prior_intercept = normal(),
-                    prior_aux = cauchy(0, 5),
-                    prior_PD = FALSE, 
-                    algorithm = c("sampling", "optimizing", 
-                                  "meanfield", "fullrank"),
-                    adapt_delta = NULL, QR = FALSE, sparse = FALSE) {
-  
+stan_glm <-
+  function(formula,
+           family = gaussian(),
+           data,
+           weights,
+           subset,
+           na.action = NULL,
+           offset = NULL,
+           model = TRUE,
+           x = FALSE,
+           y = TRUE,
+           contrasts = NULL,
+           ...,
+           prior = normal(),
+           prior_intercept = normal(),
+           prior_aux = exponential(),
+           prior_PD = FALSE,
+           algorithm = c("sampling", "optimizing", "meanfield", "fullrank"),
+           adapt_delta = NULL,
+           QR = FALSE,
+           sparse = FALSE) {
+    
   algorithm <- match.arg(algorithm)
   family <- validate_family(family)
   validate_glm_formula(formula)
@@ -204,26 +216,27 @@ stan_glm <- function(formula, family = gaussian(), data, weights, subset,
 #' @param link For \code{stan_glm.nb} only, the link function to use. See 
 #'   \code{\link{neg_binomial_2}}.
 #'   
-stan_glm.nb <- function(formula,
-                        data,
-                        weights,
-                        subset,
-                        na.action = NULL,
-                        offset = NULL,
-                        model = TRUE,
-                        x = FALSE,
-                        y = TRUE,
-                        contrasts = NULL,
-                        link = "log",
-                        ...,
-                        prior = normal(),
-                        prior_intercept = normal(),
-                        prior_aux = cauchy(0, 5),
-                        prior_PD = FALSE,
-                        algorithm = c("sampling", "optimizing", 
-                                      "meanfield", "fullrank"),
-                        adapt_delta = NULL,
-                        QR = FALSE) {
+stan_glm.nb <- 
+  function(formula,
+           data,
+           weights,
+           subset,
+           na.action = NULL,
+           offset = NULL,
+           model = TRUE,
+           x = FALSE,
+           y = TRUE,
+           contrasts = NULL,
+           link = "log",
+           ...,
+           prior = normal(),
+           prior_intercept = normal(),
+           prior_aux = exponential(),
+           prior_PD = FALSE,
+           algorithm = c("sampling", "optimizing", "meanfield", "fullrank"),
+           adapt_delta = NULL,
+           QR = FALSE) {
+    
   if ("family" %in% names(list(...)))
     stop("'family' should not be specified.")
   mc <- call <- match.call()

--- a/R/stan_glm.fit.R
+++ b/R/stan_glm.fit.R
@@ -26,23 +26,23 @@
 #'   \code{shape}, and \code{scale} components of a \code{\link{decov}}
 #'   prior for the covariance matrices among the group-specific coefficients.
 #' @importFrom lme4 mkVarCorr
-stan_glm.fit <- function(x, y, 
-                         weights = rep(1, NROW(y)), 
-                         offset = rep(0, NROW(y)), 
-                         family = gaussian(),
-                         ...,
-                         prior = normal(),
-                         prior_intercept = normal(),
-                         prior_aux = cauchy(0, 5),
-                         prior_smooth = exponential(autoscale = FALSE),
-                         prior_ops = NULL,
-                         group = list(),
-                         prior_PD = FALSE, 
-                         algorithm = c("sampling", "optimizing", 
-                                       "meanfield", "fullrank"), 
-                         adapt_delta = NULL, 
-                         QR = FALSE, 
-                         sparse = FALSE) {
+stan_glm.fit <- 
+  function(x, y, 
+           weights = rep(1, NROW(y)), 
+           offset = rep(0, NROW(y)), 
+           family = gaussian(),
+           ...,
+           prior = normal(),
+           prior_intercept = normal(),
+           prior_aux = exponential(),
+           prior_smooth = exponential(autoscale = FALSE),
+           prior_ops = NULL,
+           group = list(),
+           prior_PD = FALSE, 
+           algorithm = c("sampling", "optimizing", "meanfield", "fullrank"), 
+           adapt_delta = NULL, 
+           QR = FALSE, 
+           sparse = FALSE) {
   
   # prior_ops deprecated but make sure it still works until 
   # removed in future release
@@ -137,7 +137,7 @@ stan_glm.fit <- function(x, y,
     handle_glm_prior(
       prior_aux,
       nvars = 1,
-      default_scale = 5,
+      default_scale = 1,
       link = NULL, # don't need to adjust scale based on logit vs probit
       ok_dists = ok_aux_dists
     )
@@ -158,7 +158,8 @@ stan_glm.fit <- function(x, y,
         nvars = max(smooth_map),
         default_scale = 1,
         link = NULL,
-        ok_dists = ok_aux_dists)
+        ok_dists = ok_aux_dists
+      )
     
     names(prior_smooth_stuff) <- paste0(names(prior_smooth_stuff), "_for_smooth")
     if (is.null(prior_smooth)) {

--- a/R/stan_glmer.R
+++ b/R/stan_glmer.R
@@ -80,15 +80,25 @@
 #' 
 #' @importFrom lme4 glFormula
 #' @importFrom Matrix Matrix t cBind
-stan_glmer <- function(formula, data = NULL, family = gaussian, 
-                       subset, weights, 
-                       na.action = getOption("na.action", "na.omit"), 
-                       offset, contrasts = NULL, ...,
-                       prior = normal(), prior_intercept = normal(),
-                       prior_aux = cauchy(0, 5),
-                       prior_covariance = decov(), prior_PD = FALSE, 
-                       algorithm = c("sampling", "meanfield", "fullrank"), 
-                       adapt_delta = NULL, QR = FALSE, sparse = FALSE) {
+stan_glmer <- 
+  function(formula,
+           data = NULL,
+           family = gaussian,
+           subset,
+           weights,
+           na.action = getOption("na.action", "na.omit"),
+           offset,
+           contrasts = NULL,
+           ...,
+           prior = normal(),
+           prior_intercept = normal(),
+           prior_aux = exponential(),
+           prior_covariance = decov(),
+           prior_PD = FALSE,
+           algorithm = c("sampling", "meanfield", "fullrank"),
+           adapt_delta = NULL,
+           QR = FALSE,
+           sparse = FALSE) {
   
   call <- match.call(expand.dots = TRUE)
   mc <- match.call(expand.dots = FALSE)
@@ -143,22 +153,23 @@ stan_glmer <- function(formula, data = NULL, family = gaussian,
 
 #' @rdname stan_glmer
 #' @export
-stan_lmer <- function(formula,
-                      data = NULL,
-                      subset,
-                      weights,
-                      na.action = getOption("na.action", "na.omit"),
-                      offset,
-                      contrasts = NULL,
-                      ...,
-                      prior = normal(),
-                      prior_intercept = normal(),
-                      prior_aux = cauchy(0, 5),
-                      prior_covariance = decov(),
-                      prior_PD = FALSE,
-                      algorithm = c("sampling", "meanfield", "fullrank"),
-                      adapt_delta = NULL,
-                      QR = FALSE) {
+stan_lmer <- 
+  function(formula,
+           data = NULL,
+           subset,
+           weights,
+           na.action = getOption("na.action", "na.omit"),
+           offset,
+           contrasts = NULL,
+           ...,
+           prior = normal(),
+           prior_intercept = normal(),
+           prior_aux = exponential(),
+           prior_covariance = decov(),
+           prior_PD = FALSE,
+           algorithm = c("sampling", "meanfield", "fullrank"),
+           adapt_delta = NULL,
+           QR = FALSE) {
   if ("family" %in% names(list(...)))
     stop("'family' should not be specified.")
   mc <- call <- match.call(expand.dots = TRUE)
@@ -179,23 +190,25 @@ stan_lmer <- function(formula,
 #' @param link For \code{stan_glmer.nb} only, the link function to use. See 
 #'   \code{\link{neg_binomial_2}}.
 #' 
-stan_glmer.nb <- function(formula,
-                          data = NULL,
-                          subset,
-                          weights,
-                          na.action = getOption("na.action", "na.omit"),
-                          offset,
-                          contrasts = NULL,
-                          link = "log",
-                          ...,
-                          prior = normal(),
-                          prior_intercept = normal(),
-                          prior_aux = cauchy(0, 5),
-                          prior_covariance = decov(),
-                          prior_PD = FALSE,
-                          algorithm = c("sampling", "meanfield", "fullrank"),
-                          adapt_delta = NULL,
-                          QR = FALSE) {
+stan_glmer.nb <- 
+  function(formula,
+           data = NULL,
+           subset,
+           weights,
+           na.action = getOption("na.action", "na.omit"),
+           offset,
+           contrasts = NULL,
+           link = "log",
+           ...,
+           prior = normal(),
+           prior_intercept = normal(),
+           prior_aux = exponential(),
+           prior_covariance = decov(),
+           prior_PD = FALSE,
+           algorithm = c("sampling", "meanfield", "fullrank"),
+           adapt_delta = NULL,
+           QR = FALSE) {
+    
   if ("family" %in% names(list(...)))
     stop("'family' should not be specified.")
   mc <- call <- match.call(expand.dots = TRUE)

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,5 @@
+* prior_aux now defaults to exponential rather than Cauchy
+
 Sat April 29 2017 (2.15.3)
 1. Bug fixes
   * Fix to stan_glmer() Bernoulli models with multiple group-specific intercept terms that

--- a/vignettes/priors.Rmd
+++ b/vignettes/priors.Rmd
@@ -106,7 +106,7 @@ fr2 <- function(x) format(round(x, 2), nsmall = 2)
 Starting from the bottom up, we can see that:
 
 * __Auxiliary__: `sigma`, the error standard deviation, has a default prior that
-is $\mathsf{halfCauchy}(0, 5)$. However, as a result of the automatic rescaling,
+is $\mathsf{exponential}(1)$. However, as a result of the automatic rescaling,
 the actual scale used was `r fr2(priors$prior_aux$adjusted_scale)`.
 
 * __Coefficients__: By default the regression coefficients (in this case the 
@@ -176,7 +176,7 @@ test_no_autoscale <-
     default_prior_test,
     prior = normal(0, 5, autoscale = FALSE),
     prior_intercept = student_t(4, 0, 10, autoscale = FALSE),
-    prior_aux = exponential(1/10, autoscale=FALSE)
+    prior_aux = cauchy(0, 3, autoscale = FALSE)
   )
 ```
 


### PR DESCRIPTION
This PR changes the default `prior_aux` from `cauchy(0, 5)` to `exponential(1)`. Auto-scaling of the aux parameter (`sigma`) is done by default for Gaussian models, but that can be turned off by specifying `autoscale=FALSE` in the call to `exponential`. 