### PR TITLE
Print number of predictors for most single-level models

### DIFF
--- a/R/print-and-summary.R
+++ b/R/print-and-summary.R
@@ -69,7 +69,7 @@ print.stanreg <- function(x, digits = 1, ...) {
   cat("\n family:      ", family_plus_link(x))
   cat("\n formula:     ", formula_string(formula(x)))
   cat("\n observations:", nobs(x))
-  if (x$stan_function %in% c("stan_glm", "stan_glm.nb", "stan_lm"))
+  if (isTRUE(x$stan_function %in% c("stan_glm", "stan_glm.nb", "stan_lm")))
     cat("\n predictors:  ", length(coef(x)))
   
   cat("\n------\n")
@@ -278,7 +278,7 @@ summary.stanreg <- function(object, pars = NULL, regex_pars = NULL,
     formula = formula(object),
     posterior_sample_size = posterior_sample_size(object),
     nobs = nobs(object),
-    npreds = if (object$stan_function %in% c("stan_glm", "stan_glm.nb", "stan_lm"))
+    npreds = if (isTRUE(object$stan_function %in% c("stan_glm", "stan_glm.nb", "stan_lm")))
       length(coef(object)) else NULL,
     ngrps = if (mer) ngrps(object) else NULL,
     print.digits = digits,

--- a/R/print-and-summary.R
+++ b/R/print-and-summary.R
@@ -66,9 +66,11 @@
 #' 
 print.stanreg <- function(x, digits = 1, ...) {
   cat(x$stan_function)
-  cat("\n family:  ", family_plus_link(x))
-  cat("\n formula: ", formula_string(formula(x)))
-  cat("\n num. obs:", nobs(x))
+  cat("\n family:      ", family_plus_link(x))
+  cat("\n formula:     ", formula_string(formula(x)))
+  cat("\n observations:", nobs(x))
+  if (x$stan_function %in% c("stan_glm", "stan_glm.nb", "stan_lm"))
+    cat("\n predictors:  ", length(coef(x)))
   
   cat("\n------\n")
   cat("\nEstimates:\n")
@@ -267,18 +269,22 @@ summary.stanreg <- function(object, pars = NULL, regex_pars = NULL,
     out <- object$stan_summary[mark, , drop=FALSE]
   }
   
-  structure(out, 
-            call = object$call, 
-            algorithm = object$algorithm,
-            stan_function = object$stan_function,
-            family = family_plus_link(object),
-            formula = formula(object),
-            posterior_sample_size = posterior_sample_size(object),
-            nobs = nobs(object),
-            ngrps = if (mer) ngrps(object) else NULL,
-            print.digits = digits, 
-            priors = object$prior.info,
-            class = "summary.stanreg")
+  structure(
+    out,
+    call = object$call,
+    algorithm = object$algorithm,
+    stan_function = object$stan_function,
+    family = family_plus_link(object),
+    formula = formula(object),
+    posterior_sample_size = posterior_sample_size(object),
+    nobs = nobs(object),
+    npreds = if (object$stan_function %in% c("stan_glm", "stan_glm.nb", "stan_lm"))
+      length(coef(object)) else NULL,
+    ngrps = if (mer) ngrps(object) else NULL,
+    print.digits = digits,
+    priors = object$prior.info,
+    class = "summary.stanreg"
+  )
 }
 
 #' @rdname summary.stanreg
@@ -290,17 +296,20 @@ print.summary.stanreg <- function(x, digits = max(1, attr(x, "print.digits")),
                                   ...) {
   atts <- attributes(x)
   cat("\nModel Info:\n")
-  cat("\n function: ", atts$stan_function)
-  cat("\n family:   ", atts$family)
-  cat("\n formula:  ", formula_string(atts$formula))
-  cat("\n algorithm:", atts$algorithm)
-  cat("\n priors:   ", "see help('prior_summary')")
+  cat("\n function:    ", atts$stan_function)
+  cat("\n family:      ", atts$family)
+  cat("\n formula:     ", formula_string(atts$formula))
+  cat("\n algorithm:   ", atts$algorithm)
+  cat("\n priors:      ", "see help('prior_summary')")
   if (!is.null(atts$posterior_sample_size) && atts$algorithm == "sampling")
-    cat("\n sample:   ", atts$posterior_sample_size, "(posterior sample size)")
-  cat("\n num obs:  ", atts$nobs)
+    cat("\n sample:      ", atts$posterior_sample_size, "(posterior sample size)")
+  cat("\n observations:", atts$nobs)
+  if (!is.null(atts$npreds))
+    cat("\n predictors:  ", atts$npreds)
   if (!is.null(atts$ngrps))
-    cat("\n groups:   ", paste0(names(atts$ngrps), " (", unname(atts$ngrps), ")",
-                           collapse = ", "))
+    cat("\n groups:      ", paste0(names(atts$ngrps), " (", 
+                                   unname(atts$ngrps), ")", 
+                                   collapse = ", "))
   
   cat("\n\nEstimates:\n")
   sel <- which(colnames(x) %in% c("mcse", "n_eff", "Rhat"))


### PR DESCRIPTION
For models fit with `stan_glm` and `stan_lm` only, this PR adds a line to the `print.stanreg` and `summary.stanreg` output giving the number of predictors. I've used `length(coef(object))` to count the predictors, which will count the intercept as a predictor. In the example below the number of predictors is computed to be 4: the intercept, the `wt` variable, and the two levels of `cyl` (third level is dropped because there's an intercept). 

```r
fit <- stan_glm(mpg ~ wt + factor(cyl), data = mtcars)
print(fit)
```
```
stan_glm
 family:       gaussian [identity]
 formula:      mpg ~ wt + factor(cyl)
 observations: 32
 predictors:   4
------
(rest of print output the same as before)
```

@bgoodri If Andrew prefers to use `n` and `k` instead of `observations` and `predictors` we can change it later I guess, but I think I prefer using `observations` and `predictors`. Do you have a preference?