### PR TITLE
move `else` statement

### DIFF
--- a/R/stanreg-methods.R
+++ b/R/stanreg-methods.R
@@ -277,8 +277,7 @@ VarCorr.stanreg <- function(x, sigma = 1, ...) {
   mat <- as.matrix(x)
   cnms <- .cnms(x)
   useSc <- "sigma" %in% colnames(mat)
-  if (useSc) sc <- mat[,"sigma"]
-  else sc <- 1
+  if (useSc) sc <- mat[,"sigma"] else sc <- 1
   Sigma <- colMeans(mat[,grepl("^Sigma\\[", colnames(mat)), drop = FALSE])
   nc <- vapply(cnms, FUN = length, FUN.VALUE = 1L)
   nms <- names(cnms)


### PR DESCRIPTION
I was running through `VarCorr()` line by line to see how it works. When running code interactively, `else` can't start a new line. It raises an error. This edit fixes that.