### PR TITLE
Fix serious bug with etaauc & muauc association structures

### DIFF
--- a/src/stan_files/model/assoc_evaluate.stan
+++ b/src/stan_files/model/assoc_evaluate.stan
@@ -163,7 +163,8 @@
 					eta_auc_tmp = evaluate_eta(y1_xq_auc, y1_z1q_auc, y1_z2q_auc, 
 																 y1_z1q_id_auc, y1_z2q_id_auc, 
 																 yGamma1, yBeta1, bMat1, bMat2, 
-																 bMat1_colshift, bMat2_colshift, 0);
+																 bMat1_colshift, bMat2_colshift, 
+																 intercept_type[1]);
 				}
 				else if (m == 2) {
 					int bMat1_colshift = bK1_len[1];
@@ -171,7 +172,8 @@
 					eta_auc_tmp = evaluate_eta(y2_xq_auc, y2_z1q_auc, y2_z2q_auc, 
 																 y2_z1q_id_auc, y2_z2q_id_auc, 
 																 yGamma2, yBeta2, bMat1, bMat2, 
-																 bMat1_colshift, bMat2_colshift, 0);
+																 bMat1_colshift, bMat2_colshift, 
+																 intercept_type[2]);
 				}
 				else if (m == 3) {
 					int bMat1_colshift = sum(bK1_len[1:2]);
@@ -179,7 +181,8 @@
 					eta_auc_tmp = evaluate_eta(y3_xq_auc, y3_z1q_auc, y3_z2q_auc, 
 																 y3_z1q_id_auc, y3_z2q_id_auc, 
 																 yGamma3, yBeta3, bMat1, bMat2, 
-																 bMat1_colshift, bMat2_colshift, 0);
+																 bMat1_colshift, bMat2_colshift, 
+																 intercept_type[3]);
 				}				
         mark = mark + 1;
         for (r in 1:nrow_y_Xq[m]) {
@@ -286,7 +289,8 @@
 					eta_auc_tmp = evaluate_eta(y1_xq_auc, y1_z1q_auc, y1_z2q_auc, 
 																 y1_z1q_id_auc, y1_z2q_id_auc, 
 																 yGamma1, yBeta1, bMat1, bMat2, 
-																 bMat1_colshift, bMat2_colshift, 0);
+																 bMat1_colshift, bMat2_colshift, 
+																 intercept_type[1]);
 				}
 				else if (m == 2) {
 					int bMat1_colshift = bK1_len[1];
@@ -294,7 +298,8 @@
 					eta_auc_tmp = evaluate_eta(y2_xq_auc, y2_z1q_auc, y2_z2q_auc, 
 																 y2_z1q_id_auc, y2_z2q_id_auc, 
 																 yGamma2, yBeta2, bMat1, bMat2, 
-																 bMat1_colshift, bMat2_colshift, 0);
+																 bMat1_colshift, bMat2_colshift, 
+																 intercept_type[2]);
 				}
 				else if (m == 3) {
 					int bMat1_colshift = sum(bK1_len[1:2]);
@@ -302,7 +307,8 @@
 					eta_auc_tmp = evaluate_eta(y3_xq_auc, y3_z1q_auc, y3_z2q_auc, 
 																 y3_z1q_id_auc, y3_z2q_id_auc, 
 																 yGamma3, yBeta3, bMat1, bMat2, 
-																 bMat1_colshift, bMat2_colshift, 0);
+																 bMat1_colshift, bMat2_colshift, 
+																 intercept_type[3]);
 				}				
         mu_auc_tmp = evaluate_mu(eta_auc_tmp, family[m], link[m]);
         mark = mark + 1;


### PR DESCRIPTION
The etaauc and muauc association structures had a bug which meant that the baseline hazard estimate was wrong for joint models estimated with assoc = "etaauc" or assoc = "muauc". The regression coefficients were still correct, but the error in the baseline hazard meant that survival predictions were wrong. These errors can be seen, for example, by fitting a joint model with assoc = "etaauc" and then checking posterior predictions via the ps_check() function.

The problem was that the intercept term wasn't included in the linear predictor for the longitudinal submodel when calculating the AUC for the longitudinal submodel, leading to a shift in the linear predictor for the event submodel that wasn't corrected post-estimation.

It was a simple copy and paste error, that led to a serious bug that I hadn't picked up on. Resolved as per this commit.