### PR TITLE
Fix typos in vignettes.

### DIFF
--- a/vignettes/aov.Rmd
+++ b/vignettes/aov.Rmd
@@ -51,7 +51,7 @@ model where each of the $K$ predictors in $\mathbf{x}$ is a dummy variable
 indicating membership in a group. An equivalent linear predictor can be written
 as $\mu_j = \alpha + \alpha_j$, which expresses the conditional expectation of
 the outcome in the $j$-th group as the sum of a common mean, $\alpha$, and a
-group-specfic deviation from the common mean, $\alpha_j$.
+group-specific deviation from the common mean, $\alpha_j$.
 
 # Priors
 

--- a/vignettes/betareg.Rmd
+++ b/vignettes/betareg.Rmd
@@ -54,7 +54,7 @@ dimensional vector of parameters associated with each predictor.
 In the simplest case (with only one set of regressors), $\phi$ is a scalar
 parameter. Alternatively, it is possible to model $\phi$ using a second set of
 regressors $\mathbf{Z}$. In this context let $g_2(\cdot)$ be some link function that is not
-neccessarily identical to $g_1(\cdot)$. Then $\phi = g_2^{-1}(\mathbf{Z}\boldsymbol{\gamma})$,
+necessarily identical to $g_1(\cdot)$. Then $\phi = g_2^{-1}(\mathbf{Z}\boldsymbol{\gamma})$,
 where $\boldsymbol{\gamma}$ is a $J$ dimensional vector of parameters associated with
 the $N\times J$ dimensional matrix of predictors $\mathbf{Z}$.
 

--- a/vignettes/binomial.Rmd
+++ b/vignettes/binomial.Rmd
@@ -307,7 +307,7 @@ some important additional considerations are discussed.
 # Conditional Logit Models
 
 The previous example relies on the fact that observations are plausibly conditionally
-independent. In constrast, so-called "case-control studies" require 
+independent. In contrast, so-called "case-control studies" require
 that there are a fixed number of successes and failures within each stratum, and
 the question is _which_ members of each stratum succeed and fail? The `stan_clogit`
 function estimates such a model and is very similar to the `clogit` function in the
@@ -317,7 +317,7 @@ the `stan_clogit` function has a required `strata` argument. In addition, in the
 `stan_clogit` case the data must be sorted by the variable passed to `strata`. The 
 advantage to these changes is that `stan_clogit` can optionally utilize the multilevel 
 syntax from the **lme4** package to specify group-specific terms, rather than the more 
-limited multilevel structure supported by the `fraility` function in the **survival**
+limited multilevel structure supported by the `frailty` function in the **survival**
 package. The [vignette](glmer.html) for the `stan_glmer` function discusses the
 lme4-style syntax in more detail. For example,
 ```{r, results = "hide"}

--- a/vignettes/continuous.Rmd
+++ b/vignettes/continuous.Rmd
@@ -26,8 +26,8 @@ params:
 
 This vignette explains how to estimate linear and generalized linear models 
 (GLMs) for continuous response variables using the `stan_glm` function in the
-__rstanarm__ package. For GLMs for discrete outcomes see the vigettes for
-binary/binomial and count outcomes.
+__rstanarm__ package. For GLMs for discrete outcomes see the vignettes for
+[binary/binomial](binomial.html) and [count](count.html) outcomes.
 
 ```{r, child="children/four_steps.txt"}
 ```
@@ -86,11 +86,11 @@ $$f\left(\boldsymbol{\beta} | \mathbf{y},\mathbf{X}\right) \propto
   \prod_{i=1}^N {f(y_i|\eta_i)},$$
   
 where $\mathbf{X}$ is the matrix of predictors and $\eta$ the linear predictor. 
-This is posterior distribution that `stan_glm` will draw from when using MCMC.
+This is the posterior distribution that `stan_glm` will draw from when using MCMC.
   
 # Linear Regression Example
 
-The `stan_lm` function, which has its own [vignette](lm.stan), fits regularized linear 
+The `stan_lm` function, which has its own [vignette](lm.html), fits regularized linear
 models using a novel means of specifying priors for the regression coefficients.
 Here we focus using the `stan_glm` function, which can be used to estimate 
 linear models with independent priors on the regression coefficients.
@@ -174,7 +174,7 @@ ggplot(kidiq, aes(x = mom_iq, y = kid_score)) +
 
 For the third and fourth models, each of which uses both predictors, we can plot
 the continuous `mom_iq` on the x-axis and use color to indicate which 
-points correspond to the different subpopulatations defined by `mom_hs`. We also 
+points correspond to the different subpopulations defined by `mom_hs`. We also
 now plot two regression lines, one for each subpopulation:
 
 ```{r, continuous-kidiq-plot3}
@@ -219,7 +219,7 @@ loo4 <- loo(post4)
 ```
 
 In this case the fourth model is preferred as it has the highest 
-expected log predicted density (`elpd`) or, equivalently, the lowest 
+expected log predicted density (`elpd_loo`) or, equivalently, the lowest
 value of the LOO Information Criterion (`looic`). The fourth model
 is preferred by a lot over the first model
 

--- a/vignettes/count.Rmd
+++ b/vignettes/count.Rmd
@@ -52,7 +52,7 @@ Because the rate parameter $\lambda$ must be positive, for a Poisson GLM the
 _link_ function $g$ maps between the positive real numbers $\mathbb{R}^+$ (the
 support of $\lambda$) and the set of all real numbers $\mathbb{R}$. When applied
 to a linear predictor $\eta$ with values in $\mathbb{R}$, the inverse link
-function $g^{-1}(\eta)$ therefore returns a positve real number.
+function $g^{-1}(\eta)$ therefore returns a positive real number.
 
 Although other link functions are possible, the canonical link function for a 
 Poisson GLM is the log link $g(x) = \ln{(x)}$. With the log link, the inverse
@@ -187,7 +187,7 @@ from the sample `y` is the dark blue vertical line. More than 30% of these
 observations are zeros, whereas the replicated datasets all contain less than 1%
 zeros. This is a sign that we should consider a model that more accurately
 accounts for the large proportion of zeros in the data. Gelman and Hill show how
-we can do this using an overdispered Poisson regression. To illustrate the use
+we can do this using an overdispersed Poisson regression. To illustrate the use
 of a different `stan_glm` model, here we will instead try
 [negative binomial](https://en.wikipedia.org/wiki/Negative_binomial_distribution) 
 regression, which is also used for overdispersed or zero-inflated count data.

--- a/vignettes/glmer.Rmd
+++ b/vignettes/glmer.Rmd
@@ -64,7 +64,7 @@ a "parameter" to be estimated because parameters are unknown constants that are
 fixed in repeated sampling.
 
 Bayesians condition on the data in-hand without reference to repeated sampling
-and describe their _beliefs_ about the unknows with prior distributions before
+and describe their _beliefs_ about the unknowns with prior distributions before
 observing the data. Thus, the likelihood in a simple hierarchical model in
 __rstarnarm__ is
 $$\mathbf{y} \thicksim \mathcal{N}\left(\alpha + \mathbf{X}\boldsymbol{\beta} + \mathbf{Z}\mathbf{b}, \sigma^2 \mathbf{I}\right)$$
@@ -88,7 +88,7 @@ if there actually were no between-group heterogeneity. Group-by-group analyses, 
 the other hand, are valid but produces estimates that are relatively imprecise. 
 While complete pooling or no pooling of data across groups is sometimes called for, 
 models that ignore the grouping structures in the data tend to underfit or overfit 
-(Gelman et al.,2013). Hierachical modeling provides a compromise by allowing parameters 
+(Gelman et al.,2013). Hierarchical modeling provides a compromise by allowing parameters
 to vary by group at lower levels of the hierarchy while estimating common
 parameters at higher levels. Inference for each group-level parameter is
 informed not only by the group-specific information contained in the data but
@@ -106,7 +106,7 @@ priors are discussed in greater detail below.
 
 # Priors on covariance matrices
 
-In this section we dicuss a flexible family of prior distributions for the
+In this section we discuss a flexible family of prior distributions for the
 unknown covariance matrices of the group-specific coefficients.
 
 
@@ -191,7 +191,7 @@ advantages as well as an important disadvantage.
 While __lme4__ uses (restricted) maximum likelihood (RE)ML estimation, 
 __rstanarm__ enables full Bayesian inference via MCMC to be performed. It is
 well known that (RE)ML tends to underestimate uncertainties because it relies on
-point estimates of hyperparameters. Full Bayes, on the other hand, propogates
+point estimates of hyperparameters. Full Bayes, on the other hand, propagates
 the uncertainty in the hyperparameters throughout all levels of the model and 
 provides more appropriate estimates of uncertainty for models that consist of a 
 mix of common and group-specific parameters.
@@ -336,7 +336,7 @@ post1
 ```
 
 In `stan_nlmer`, it is not necessary to supply starting values; however, in this
-case it was necessary to specify the `init_r` argument so that the ranomly-chosen
+case it was necessary to specify the `init_r` argument so that the randomly-chosen
 starting values were not more than $0.5$ away from zero (in the unconstrained
 parameter space). The default value of $2.0$ produced suboptimal results.
 

--- a/vignettes/jm.Rmd
+++ b/vignettes/jm.Rmd
@@ -395,7 +395,7 @@ p \Big( y^{*}_{km}(t) \mid \mathcal{D} \Big)
 \end{aligned}
 $$
 
-and similiarly for the survival probability
+and similarly for the survival probability
 
 $$ 
 \begin{aligned}
@@ -515,7 +515,7 @@ help("datasets", package = "rstanarm")
 
 In this example we fit a simple univariate joint model, with one normally distributed longitudinal marker, an association structure based on the current value of the linear predictor, and B-splines baseline hazard. To fit the model we use the joint (longitudinal and time-to-event) modelling function in the **rstanarm** package: `stan_jm`. When calling `stan_jm` we must, at a minimum, specify a formula object for each of the longitudinal and event submodels (through the arguments `formulaLong` and `formulaEvent`), the data frames which contain the variables for each of the the longitudinal and event submodels (through the arguments `dataLong` and `dataEvent`), and the name of the variable representing time in the longitudinal submodel (through the argument `time_var`).
 
-The formula for the longitudinal submodel is specified using the **lme4** package formula style. That is `y ~ x + (random_effects | grouping_factor)`. In this example we specify that log serum bilirubin (`logBili`) follows a subject-specific linear trajectory. To do this we include a fixed intercept and fixed slope (`year`), as well as a random intecept and random slope for each subject `id` (`(year | id)`).
+The formula for the longitudinal submodel is specified using the **lme4** package formula style. That is `y ~ x + (random_effects | grouping_factor)`. In this example we specify that log serum bilirubin (`logBili`) follows a subject-specific linear trajectory. To do this we include a fixed intercept and fixed slope (`year`), as well as a random intercept and random slope for each subject `id` (`(year | id)`).
 
 The formula for the event submodel is specified using the **survival** package formula style. That is, the outcome of the left of the `~` needs to be of the format `Surv(event_time, event_indicator)` for single row per individual data, or `Surv(start_time, stop_time, event_indicator)` for multiple row per individual data. The latter allows for exogenous time-varying covariates to be included in the event submodel. In this example we assume that the log hazard of death is linearly related to gender (`sex`) and an indicator of treatment with D-penicillamine (`trt`).
 
@@ -531,7 +531,7 @@ mod1 <- stan_jm(formulaLong = logBili ~ sex + trt + year + (year | id),
 
 The argument `refresh = 2000` was specified so that Stan didn't provide us with excessive progress updates whilst fitting the model. However, if you are fitting a model that will take several minutes or hours to fit, then you may wish to request progress updates quite regularly, for example setting `refresh = 20` for every 20 iterations (by default the refresh argument is set to 1/10th of the total number of iterations). 
 
-The fitted model is returned as an object of the S3 class `stanjm`. We have a variety of methods and postestimation functions available for this class, including: `print`, `summary`, `plot`, `fixef`, `ranef`, `coef`, `VarCorr`, `posterior_interval`, `update`, and more. Here, we will examine the most basic output for the fitted joint model by typing `print(f1)`:
+The fitted model is returned as an object of the S3 class `stanjm`. We have a variety of methods and post-estimation functions available for this class, including: `print`, `summary`, `plot`, `fixef`, `ranef`, `coef`, `VarCorr`, `posterior_interval`, `update`, and more. Here, we will examine the most basic output for the fitted joint model by typing `print(f1)`:
 
 ```{r print, echo = FALSE}
 print(mod1)

--- a/vignettes/lm.Rmd
+++ b/vignettes/lm.Rmd
@@ -102,7 +102,7 @@ correlation between the $k$th column of $\mathbf{Q}$ and the outcome, $\sigma_Y$
 is the standard deviation of the outcome, and $\frac{1}{\sqrt{N-1}}$ is the
 standard deviation of the $k$ column of $\mathbf{Q}$. Then let 
 $\boldsymbol{\rho} = \sqrt{R^2}\mathbf{u}$ where $\mathbf{u}$ is a unit vector
-that is uniformally distributed on the surface of a hypersphere. Consequently,
+that is uniformly distributed on the surface of a hypersphere. Consequently,
 $R^2 = \boldsymbol{\rho}^\top \boldsymbol{\rho}$ is the familiar coefficient of
 determination for the linear model.
 
@@ -340,8 +340,8 @@ output of the `biglm` function in the __biglm__ package, which utilizes an
 incremental QR decomposition that does not require the entire dataset to be
 loaded into memory simultaneously. However, the `biglm` function needs to be
 called in a particular way in order to work with `stan_biglm`. In particular,
-The meansof the columns of the design matrix, the sample mean of the outcome, and 
-the sample standard deviation of the outocme all need to be passed to the `stan_biglm` 
+The means of the columns of the design matrix, the sample mean of the outcome, and
+the sample standard deviation of the outcome all need to be passed to the `stan_biglm`
 function, as well as a flag indicating whether the model really does include an
 intercept. Also, the number of columns of the design matrix currently cannot 
 exceed the number of rows. Although `stan_biglm` should run fairly quickly and

--- a/vignettes/pooling.Rmd
+++ b/vignettes/pooling.Rmd
@@ -54,7 +54,7 @@ The content of the vignette is based on Bob Carpenter's Stan tutorial
 *[Hierarchical Partial Pooling for Repeated Binary Trials](http://mc-stan.org/users/documentation/case-studies/pool-binary-trials.html)*,
 but here we show how to fit the models and carry out predictions and model 
 checking and comparison using **rstanarm**. Most of the text is taken from the 
-original, with some additions and substractions to make the content more useful 
+original, with some additions and subtractions to make the content more useful
 for **rstanarm** users. The Stan code from the original tutorial has also been 
 entirely removed, as **rstanarm** will fit all of the models in Stan without the
 user having to write the underlying Stan programs. The Stan code in the original
@@ -285,7 +285,7 @@ batting_avg(pool)
 
 With more data, such as from more players or from the rest of the season, the
 posterior approaches a delta function around the maximum likelihood estimate and
-the posterior interval around the centeral posterior intervals will shrink. 
+the posterior interval around the central posterior intervals will shrink.
 Nevertheless, even if we know a player's chance of success exactly, there is a
 large amount of uncertainty in running $K$ binary trials with that chance of
 success; using a binomial model fundamentally bounds our prediction accuracy.
@@ -303,7 +303,7 @@ independent.
 
 **rstanarm** will again parameterize the model in terms of the log-odds, 
 $\alpha_n = \mathrm{logit}(\theta_n)$, so the likelihood then uses the log-odds
-of succes $\alpha_n$ for unit $n$ in modeling the number of successes $y_n$ as
+of success $\alpha_n$ for unit $n$ in modeling the number of successes $y_n$ as
 
 \[
 p(y_n \, | \, \alpha_n) = 
@@ -493,7 +493,7 @@ conditioned on $y$.
 Because the posterior predictive density is formulated as an
 expectation over the posterior, it is possible to compute via MCMC.
 With $M$ draws $\theta^{(m)}$ from the posterior $p(\theta \, | \,
-y)$, the posterior predicitve log density for new data
+y)$, the posterior predictive log density for new data
 $y^{\mathrm{new}}$ is given by the MCMC approximation
 
 \[
@@ -530,7 +530,7 @@ the season based on their initial 45 at bats.
 
 ### Calibration
 
-A well calibrated statistical model is one in which the uncertainy in
+A well calibrated statistical model is one in which the uncertainty in
 the predictions matches the uncertainty in further data.  That is, if
 we estimate posterior 50% intervals for predictions on new data (here,
 number of hits in the rest of the season for each player), roughly 50%
@@ -581,7 +581,7 @@ intervals (Gneiting et al. 2007).
 
 ### $\log E[p(\tilde{y} \, | \, \theta)]$ vs $E[\log p(\tilde{y} \, | \, \theta)]$
 
-The log of posterior predicitve density is defined in the obvious way as
+The log of posterior predictive density is defined in the obvious way as
 
 \[
 \log p(\tilde{y} \, | \, y)
@@ -746,7 +746,7 @@ log_sum_exp <- function(u) {
   max_u + log(a)
 }
 
-# Or equivalenty using vectorization
+# Or equivalently using vectorization
 log_sum_exp <- function(u) {
   max_u <- max(u)
   max_u + log(sum(exp(u - max_u)))
@@ -779,7 +779,7 @@ slightly better predictions than the no pooling model.
 
 #### Approximating the expected log predictive density
 
-Ventari, Gelman, and Gabry (2016) shows that the expected log predictive 
+Vehtari, Gelman, and Gabry (2016) shows that the expected log predictive
 density can be approximated using the `loo` function for each model and 
 then compared across models:
 ```{r, loo}
@@ -1090,7 +1090,7 @@ chance_gt_350 <- round(100 * colMeans(some_gt_350_all))
 
 The probability estimate of there being a player with an ability (chance of
 success) greater than 0.350 is essentially zero in the complete and 
-is essentually guaranteed in the no pooling model. The partially pooled
+is essentially guaranteed in the no pooling model. The partially pooled
 estimates would not be considered significant at conventional p=0.05 thresholds. 
 One way to get a handle on what's going on is to inspect the posterior 80%
 intervals for chance-of-success estimates in the first graph above.
@@ -1253,7 +1253,7 @@ Y^{\mathrm{rep}}$.  As usual, we use the integration sign in a general
 way intended to include summation, as with the discrete variable
 $y^{\mathrm{rep}}$.
 
-The formualation as an expectation leads to the obvious MCMC
+The formulation as an expectation leads to the obvious MCMC
 calculation based on posterior draws $y^{\mathrm{rep} (m)}$ for
 $m \in 1{:}M$,
 
@@ -1281,7 +1281,7 @@ functions defined in the Global Environment) that takes a vector as an input and
 returns a scalar. 
 
 To make plots for each of the models for several test statistics we can use the
-following code, which will greate a list of ggplot objects for each model and 
+following code, which will create a list of ggplot objects for each model and
 then arrange everything in a single plot.
 
 ```{r, plot-ppc-stats}
@@ -1377,7 +1377,7 @@ other than provide more informative priors, which is well worth doing when prior
 information is available.
 
 On the other hand, with more data, the models provide similar results (see the
-exericses), and in the limit, all of the models (other than complete pooling)
+exercises), and in the limit, all of the models (other than complete pooling)
 converge to posteriors that are delta functions around the empirical chance of 
 success (i.e., the maximum likelihood estimate).  Meanwhile, Bayesian inference
 is allowing us to make more accurate predictions with the data available before
@@ -1480,7 +1480,7 @@ variable itself?  Why might this be important in inference?
 * Tarone, R. E. (1982) The use of historical control information in
   testing for a trend in proportions. *Biometrics* **38**(1):215--220.
   
-* Ventari, A, Gelman, A., & Gabry, J. (2016)  Practical Bayesian model 
+* Vehtari, A, Gelman, A., & Gabry, J. (2016)  Practical Bayesian model
   evaluation using leave-one-out cross-validation and WAIC. [
   [pdf](http://arxiv.org/abs/1507.04544)
   ]

--- a/vignettes/rstanarm.Rmd
+++ b/vignettes/rstanarm.Rmd
@@ -112,7 +112,7 @@ model parameters, but other times such work may not exist or several studies may
 make contradictory claims. Regardless, we nearly always have _some_ knowledge 
 that should be reflected in our choice of prior distributions. For example, no 
 one believes a logistic regression coefficient will be greater than five in 
-absoluate value if the predictors are scaled reasonably. You may also have seen 
+absolute value if the predictors are scaled reasonably. You may also have seen
 examples of so-called "non-informative" (or "vague", "diffuse", etc.) priors 
 like a normal distribution with a variance of 1000. When data are reasonably 
 scaled, these priors are almost always a bad idea for various reasons (they give
@@ -143,7 +143,7 @@ p-value for the null hypothesis that $\beta_2 = 0$ is very large. However,
 frequentist p-values are awkward because they do not pertain to the probability 
 that a scientific hypothesis is true but rather to the probability of observing 
 a $z$-statistic that is so large (in magnitude) if the null hypothesis were
-true. The desire to make probabalistic statements about a scientific hypothesis
+true. The desire to make probabilistic statements about a scientific hypothesis
 is one reason why many people are drawn to the Bayesian approach.
 
 A model with the same likelihood but Student t priors with seven degrees of 
@@ -183,7 +183,7 @@ $\beta_2$ is between `ci95[1,1]` and `ci95[1,2]`. Alternatively, we could say
 that there is essentially zero probability that $\beta_2 > 0$, although
 frequentists cannot make such a claim coherently.
 
-Many of the postestimation methods that are available for a model that is 
+Many of the post-estimation methods that are available for a model that is
 estimated by `glm` are also available for a model that is estimated by 
 `stan_glm`. For example,
 ```{r rstanarm-methods}
@@ -209,8 +209,8 @@ launch_shinystan(womensrole_bglm_1)
 ```
 which will open a web browser that drives the visualizations. 
 
-For the rest of this subsection, we focus on what users can do programatically 
-to evaluate whether a model is adequate. A minimal requirement for a Bayesian 
+For the rest of this subsection, we focus on what users can do programmatically
+to evaluate whether a model is adequate. A minimal requirement for Bayesian
 estimates is that the model should fit the data that the estimates conditioned 
 on. The key function here is `posterior_predict`, which can be passed a new 
 `data.frame` to predict out-of-sample, but in this case is omitted to obtain 
@@ -295,7 +295,7 @@ taking into account that the second model estimates an additional parameter. The
 ```{r, rstanarm-loo-print}
 loo_bglm_1
 ```
-has the same purpose as the Aikaike Information Criterion (AIC) that is used by 
+has the same purpose as the Akaike Information Criterion (AIC) that is used by
 frequentists. Both are intended to estimate the expected log predicted density 
 (ELPD) for a new dataset. However, the AIC ignores priors and assumes that the 
 posterior distribution is multivariate normal, whereas the functions from the 
@@ -312,7 +312,7 @@ interaction terms. Bayesians can avoid this difficulty simply by inspecting the
 posterior predictive distribution at different levels of the predictors. For
 example,
 ```{r, rstanarm-posterior_predict-manipulate}
-# note: in newdata we want agree and disgree to sum to the number of people we
+# note: in newdata we want agree and disagree to sum to the number of people we
 # want to predict for. the values of agree and disagree don't matter so long as
 # their sum is the desired number of trials. we need to explicitly imply the
 # number of trials like this because our original data are aggregate. if we had
@@ -393,7 +393,7 @@ parameters with an Rhat greater than 1.1:
 any(summary(good_rhat)[, "Rhat"] > 1.1)
 ```
 
-Details on the computatation of Rhat and some of its limitations can be found in
+Details on the computation of Rhat and some of its limitations can be found in
 the  chapter of the [Stan Modeling Language User's Guide and Reference
 Manual](http://mc-stan.org/documentation/).
 
@@ -469,7 +469,7 @@ sampled from using the __rstanarm__ package, then it is often possible to create
 a hand-written program in the the Stan language so that the posterior 
 distribution can be drawn from using the __rstan__ package. See the 
 documentation for the __rstan__ package or http://mc-stan.org for more details
-about this more advanced useage of Stan. However, many relatively simple models
+about this more advanced usage of Stan. However, many relatively simple models
 can be fit using the __rstanarm__ package without writing any code in the Stan
 language, which is illustrated for each estimating function in the __rstanarm__
 package in the other [vignettes](index.html).


### PR DESCRIPTION
This fixes a number of typos in the source files for the vignettes. In one or two cases, it also fixes broken links between the vignettes.