### PR TITLE
Print aux separately

### DIFF
--- a/R/print-and-summary.R
+++ b/R/print-and-summary.R
@@ -72,19 +72,28 @@ print.stanreg <- function(x, digits = 1, ...) {
   cat("\n family:      ", family_plus_link(x))
   cat("\n formula:     ", formula_string(formula(x)))
   cat("\n observations:", nobs(x))
-  if (isTRUE(x$stan_function %in% c("stan_glm", "stan_glm.nb", "stan_lm")))
+  if (isTRUE(x$stan_function %in% 
+             c("stan_glm", "stan_glm.nb", "stan_lm", "stan_aov"))) {
     cat("\n predictors:  ", length(coef(x)))
+  }
   
   cat("\n------\n")
 
   mer <- is.mer(x)
+  gamm <- isTRUE(x$stan_function == "stan_gamm4")
   ord <- is_polr(x) && !("(Intercept)" %in% rownames(x$stan_summary))
 
+  aux_nms <- .aux_name(x)
+  
   if (!used.optimizing(x)) {
-    aux_nm <- .aux_name(x)
+    
+    if (isTRUE(x$stan_function %in% c("stan_lm", "stan_aov"))) {
+      aux_nms <- c("R2", "log-fit_ratio", aux_nms)
+    }
     mat <- as.matrix(x$stanfit) # don't used as.matrix.stanreg method b/c want access to mean_PPD
-    nms <- setdiff(rownames(x$stan_summary), c("log-posterior", aux_nm))
-    if (isTRUE(x$stan_function == "stan_gamm4")) {
+    nms <- setdiff(rownames(x$stan_summary), c("log-posterior", aux_nms))
+    
+    if (gamm) {
       smooth_sd_nms <- grep("^smooth_sd\\[", nms, value = TRUE)
       nms <- setdiff(nms, smooth_sd_nms)
       smooth_sd_mat <- mat[, smooth_sd_nms, drop = FALSE]
@@ -105,22 +114,22 @@ print.stanreg <- function(x, digits = 1, ...) {
     ppd_mat <- mat[, ppd_nms, drop = FALSE]
     estimates <- .median_and_madsd(coef_mat)
     ppd_estimates <- .median_and_madsd(ppd_mat)
+    
     if (mer) {
       estimates <- estimates[!grepl("^Sigma\\[", rownames(estimates)),, drop=FALSE]
     }
     .printfr(estimates, digits, ...)
     
-    if (length(aux_nm)) {
-      aux_estimates <- .median_and_madsd(mat[, aux_nm, drop=FALSE])
+    if (length(aux_nms)) {
+      aux_estimates <- .median_and_madsd(mat[, aux_nms, drop=FALSE])
       cat("\nAuxiliary parameter(s):\n")
       .printfr(aux_estimates, digits, ...)
     }
-    
     if (ord) {
       cat("\nCutpoints:\n")
       .printfr(cut_estimates, digits, ...)
     }
-    if (isTRUE(x$stan_function == "stan_gamm4")) {
+    if (gamm) {
       cat("\nSmoothing terms:\n")
       .printfr(smooth_sd_estimates, digits, ...)
     }
@@ -130,7 +139,10 @@ print.stanreg <- function(x, digits = 1, ...) {
       cat("Num. levels:", 
           paste(names(ngrps(x)), unname(ngrps(x)), collapse = ", "), "\n")
     }
-    if (!isTRUE(x$stan_function == "stan_clogit")) {
+    if (is(x, "aov")) {
+      print_anova_table(x, digits, ...)
+    }
+    if (!is_clogit(x)) {
       cat("\nSample avg. posterior predictive distribution of y:\n")
       .printfr(ppd_estimates, digits, ...)
     }
@@ -138,44 +150,21 @@ print.stanreg <- function(x, digits = 1, ...) {
   } else { 
     # used optimization
     nms <- names(x$coefficients)
-    aux_nm <- .aux_name(x)
     ppd_nms <- grep("^mean_PPD", rownames(x$stan_summary), value = TRUE)
     
     estimates <- x$stan_summary[nms, 1:2, drop=FALSE]
     .printfr(estimates, digits, ...)
     
-    if (length(aux_nm)) {
+    if (length(aux_nms)) {
       cat("\nAuxiliary parameter(s):\n")
-      .printfr(x$stan_summary[aux_nm, 1:2, drop=FALSE], digits, ...)
+      .printfr(x$stan_summary[aux_nms, 1:2, drop=FALSE], digits, ...)
     }
-    
     if (length(ppd_nms)) {
       cat("\nSample avg. posterior predictive distribution of y:\n")
       .printfr(x$stan_summary[ppd_nms, 1:2, drop=FALSE], digits, ...)
     }
   }
   
-  if (is(x, "aov")) {
-    labels <- attributes(x$terms)$term.labels
-    patterns <- gsub(":", ".*:", labels)
-    dnms <- dimnames(extract(x$stanfit, pars = "beta", 
-                             permuted = FALSE))$parameters
-    groups <- sapply(patterns, simplify = FALSE, FUN = grep, x = dnms)
-    names(groups) <- gsub(".*", "", names(groups), fixed = TRUE)
-    groups <- groups[sapply(groups, length) > 0]
-    effects_dim <- dim(x$effects)
-    effects <- x$effects^2
-    effects <- sapply(groups, FUN = function(i) {
-      apply(effects[, , i, drop = FALSE], 1:2, mean)
-    })
-    dim(effects) <- c(effects_dim[-3], ncol(effects))
-    dim(effects) <- c(nrow(effects) * ncol(effects), dim(effects)[3])
-    colnames(effects) <- paste("Mean Sq", names(groups))
-    cat("\nANOVA-like table:\n")
-    anova_table <- .median_and_madsd(effects)
-    .printfr(anova_table, digits, ...)
-  }
-
   cat("\n------\n")
   cat("For info on the priors used see help('prior_summary.stanreg').\n")
   
@@ -723,3 +712,26 @@ formula_string <- function(formula, break_and_indent = TRUE) {
   return(aux)
 }
 
+
+# print anova table for stan_aov models
+# @param x stanreg object created by stan_aov()
+print_anova_table <- function(x, digits, ...) {
+  labels <- attributes(x$terms)$term.labels
+  patterns <- gsub(":", ".*:", labels)
+  dnms <- dimnames(extract(x$stanfit, pars = "beta", 
+                           permuted = FALSE))$parameters
+  groups <- sapply(patterns, simplify = FALSE, FUN = grep, x = dnms)
+  names(groups) <- gsub(".*", "", names(groups), fixed = TRUE)
+  groups <- groups[sapply(groups, length) > 0]
+  effects_dim <- dim(x$effects)
+  effects <- x$effects^2
+  effects <- sapply(groups, FUN = function(i) {
+    apply(effects[, , i, drop = FALSE], 1:2, mean)
+  })
+  dim(effects) <- c(effects_dim[-3], ncol(effects))
+  dim(effects) <- c(nrow(effects) * ncol(effects), dim(effects)[3])
+  colnames(effects) <- paste("Mean Sq", names(groups))
+  anova_table <- .median_and_madsd(effects)
+  cat("\nANOVA-like table:\n")
+  .printfr(anova_table, digits, ...)
+}

--- a/R/stan_aov.R
+++ b/R/stan_aov.R
@@ -25,9 +25,10 @@
 #' @examples
 #' \donttest{
 #' op <- options(contrasts = c("contr.helmert", "contr.poly"))
-#' stan_aov(yield ~ block + N*P*K, data = npk,
-#'          prior = R2(0.5), seed = 12345) 
+#' fit_aov <- stan_aov(yield ~ block + N*P*K, data = npk,
+#'          prior = R2(0.5), seed = 12345)
 #' options(op)
+#' print(fit_aov)
 #' }
 #'             
 stan_aov <- function(formula, data, projections = FALSE,

--- a/R/stan_glm.fit.R
+++ b/R/stan_glm.fit.R
@@ -916,6 +916,7 @@ summarize_glm_prior <-
     return(prior_list)
   }
 
+# rename aux parameter based on family
 .rename_aux <- function(family) {
   fam <- family$family
   if (is.gaussian(fam)) "sigma" else

--- a/R/stan_lm.R
+++ b/R/stan_lm.R
@@ -93,10 +93,11 @@
 #'   checking convergence because it is reasonably normally distributed
 #'   and a function of all the parameters in the model.
 #'   
-#'   The \code{stan_aov} function is similar to \code{\link[stats]{aov}} and
-#'   has a somewhat customized \code{\link{print}} method but basically just 
-#'   calls \code{stan_lm} with dummy variables to do a Bayesian analysis of
-#'   variance.
+#'   The \code{stan_aov} function is similar to \code{\link[stats]{aov}}, but
+#'   does a Bayesian analysis of variance that is basically equivalent to
+#'   \code{stan_lm} with dummy variables. \code{stan_aov} has a somewhat
+#'   customized \code{\link{print}} method that prints an ANOVA-like table in
+#'   addition to the output printed for \code{stan_lm} models.
 #'   
 #'   
 #' @references 


### PR DESCRIPTION
Separates the printing of auxiliary variables (and marks them as such) in order to distinguish them from regression coefficients in the printed output. 

```
stan_glm
 family:       gaussian [identity]
 formula:      mpg ~ wt + cyl
 observations: 32
 predictors:   3
------
            Median MAD_SD
(Intercept) 39.7    1.7  
wt          -3.2    0.7  
cyl         -1.5    0.4  

Auxiliary parameter(s):
      Median MAD_SD
sigma 2.6    0.4   
```

This should be clear to the user since sigma (and the other auxiliary parameters for other GLMs) are specified via `prior_aux` and are referred to as auxiliary parameters in the doc. 

Closes #284