### PR TITLE
Function "nsamples()" for stanreg models

### DIFF
--- a/R/nsamples
+++ b/R/nsamples
@@ -1,0 +1,10 @@
+#' @importFrom purrr map_dbl
+#' @export
+nsamples.stanreg <- function(x, incl_warmup = FALSE, ...) {
+  if (incl_warmup)
+    x <- purrr::map_dbl(x$stanfit@stan_args, ~ .x$iter)
+  else
+    x <- purrr::map_dbl(x$stanfit@stan_args, ~ .x$iter - .x$warmup)
+
+  sum(x)
+}


### PR DESCRIPTION
This is a short and convenient wrappter to extract the number of samples, similar to what @paul-buerkner has implemented in _brms_ (https://github.com/paul-buerkner/brms/blob/master/R/generics.R).

The generic and the _brmsfit_-methods are both in the package _brms_, but maybe it would make sense to move the generic to _rstantools_?