### PR TITLE
mean_PPD argument for stan_glm

### DIFF
--- a/R/stan_glm.R
+++ b/R/stan_glm.R
@@ -58,7 +58,18 @@
 #'   matrix and the remaining list elements collectively constitute a basis for a
 #'   smooth nonlinear function of the predictors indicated by the \code{formula}
 #'   argument to \code{\link{stan_gamm4}}.
-
+#' @param mean_PPD A logical value indicating whether the sample mean of the
+#'   posterior predictive distribution of the outcome should be calculated. If
+#'   \code{TRUE} then \code{mean_PPD} is computed and displayed as a diagnostic
+#'   in the \link[=print.stanreg]{printed output}. The default is \code{TRUE}
+#'   except if \code{algorithm=="optimizing"}. A useful heuristic is to check if
+#'   \code{mean_PPD} is plausible when compared to \code{mean(y)}. If it is
+#'   plausible then this does \emph{not} mean that the model is good in general
+#'   (only that it can reproduce the sample mean), but if \code{mean_PPD} is
+#'   implausible then there may be something wrong, e.g., severe model
+#'   misspecification, problems with the data and/or priors, computational
+#'   issues, etc.
+#' 
 #' @details The \code{stan_glm} function is similar in syntax to 
 #'   \code{\link[stats]{glm}} but rather than performing maximum likelihood 
 #'   estimation of generalized linear models, full Bayesian estimation is 
@@ -165,6 +176,7 @@ stan_glm <-
            prior_aux = exponential(),
            prior_PD = FALSE,
            algorithm = c("sampling", "optimizing", "meanfield", "fullrank"),
+           mean_PPD = algorithm != "optimizing",
            adapt_delta = NULL,
            QR = FALSE,
            sparse = FALSE) {
@@ -196,22 +208,37 @@ stan_glm <-
     weights <- double(0)
   }
 
-  stanfit <- stan_glm.fit(x = X, y = Y, weights = weights, 
-                          offset = offset, family = family,
-                          prior = prior, 
-                          prior_intercept = prior_intercept,
-                          prior_aux = prior_aux,
-                          prior_PD = prior_PD, 
-                          algorithm = algorithm, adapt_delta = adapt_delta, 
-                          QR = QR, sparse = sparse, ...)
-  if (family$family == "Beta regression") family$family <- "beta"
+  stanfit <- stan_glm.fit(
+    x = X,
+    y = Y,
+    weights = weights,
+    offset = offset,
+    family = family,
+    prior = prior,
+    prior_intercept = prior_intercept,
+    prior_aux = prior_aux,
+    prior_PD = prior_PD,
+    algorithm = algorithm,
+    mean_PPD = mean_PPD,
+    adapt_delta = adapt_delta,
+    QR = QR,
+    sparse = sparse,
+    ...
+  )
+  
+  if (family$family == "Beta regression") {
+    family$family <- "beta"
+  }
+  
   sel <- apply(X, 2L, function(x) !all(x == 1) && length(unique(x)) < 2)
   X <- X[ , !sel, drop = FALSE]  
+  
   fit <- nlist(stanfit, algorithm, family, formula, data, offset, weights,
                x = X, y = Y, model = mf,  terms = mt, call, 
                na.action = attr(mf, "na.action"), 
                contrasts = attr(X, "contrasts"), 
                stan_function = "stan_glm")
+  
   out <- stanreg(fit)
   out$xlevels <- .getXlevels(mt, mf)
   if (!x) 
@@ -247,6 +274,7 @@ stan_glm.nb <-
            prior_aux = exponential(),
            prior_PD = FALSE,
            algorithm = c("sampling", "optimizing", "meanfield", "fullrank"),
+           mean_PPD = algorithm != "optimizing",
            adapt_delta = NULL,
            QR = FALSE) {
     

--- a/R/stan_glm.R
+++ b/R/stan_glm.R
@@ -59,10 +59,11 @@
 #'   smooth nonlinear function of the predictors indicated by the \code{formula}
 #'   argument to \code{\link{stan_gamm4}}.
 #' @param mean_PPD A logical value indicating whether the sample mean of the
-#'   posterior predictive distribution of the outcome should be calculated. If
-#'   \code{TRUE} then \code{mean_PPD} is computed and displayed as a diagnostic
-#'   in the \link[=print.stanreg]{printed output}. The default is \code{TRUE}
-#'   except if \code{algorithm=="optimizing"}. A useful heuristic is to check if
+#'   posterior predictive distribution of the outcome should be calculated in
+#'   the \code{generated quantities} block. If \code{TRUE} then \code{mean_PPD}
+#'   is computed and displayed as a diagnostic in the
+#'   \link[=print.stanreg]{printed output}. The default is \code{TRUE} except if
+#'   \code{algorithm=="optimizing"}. A useful heuristic is to check if
 #'   \code{mean_PPD} is plausible when compared to \code{mean(y)}. If it is
 #'   plausible then this does \emph{not} mean that the model is good in general
 #'   (only that it can reproduce the sample mean), but if \code{mean_PPD} is
@@ -240,6 +241,7 @@ stan_glm <-
                stan_function = "stan_glm")
   
   out <- stanreg(fit)
+  out$compute_mean_PPD <- mean_PPD
   out$xlevels <- .getXlevels(mt, mf)
   if (!x) 
     out$x <- NULL

--- a/R/stan_glm.fit.R
+++ b/R/stan_glm.fit.R
@@ -40,6 +40,7 @@ stan_glm.fit <-
            group = list(),
            prior_PD = FALSE, 
            algorithm = c("sampling", "optimizing", "meanfield", "fullrank"), 
+           mean_PPD = algorithm != "optimizing",
            adapt_delta = NULL, 
            QR = FALSE, 
            sparse = FALSE) {
@@ -260,6 +261,7 @@ stan_glm.fit <-
     has_offset = length(offset) > 0,
     has_intercept,
     prior_PD,
+    compute_mean_PPD = mean_PPD,
     prior_dist,
     prior_mean,
     prior_scale,

--- a/src/stan_files/bernoulli.stan
+++ b/src/stan_files/bernoulli.stan
@@ -142,13 +142,16 @@ model {
                       regularization, delta, shape, t, p);
 }
 generated quantities {
+  real mean_PPD = negative_infinity();
   real alpha[has_intercept];
-  real mean_PPD = 0;
+  
   if (has_intercept == 1) {
     if (dense_X) alpha[1] = gamma[1] - dot_product(xbar, beta);
     else alpha[1] = gamma[1];
   }
-  {
+  
+  if (compute_mean_PPD) {
+    mean_PPD = 0;
     vector[N[1]] pi0;
     vector[N[2]] pi1;
     // defines eta0, eta1

--- a/src/stan_files/bernoulli.stan
+++ b/src/stan_files/bernoulli.stan
@@ -142,7 +142,7 @@ model {
                       regularization, delta, shape, t, p);
 }
 generated quantities {
-  real mean_PPD = negative_infinity();
+  real mean_PPD = compute_mean_PPD ? 0 : negative_infinity();
   real alpha[has_intercept];
   
   if (has_intercept == 1) {
@@ -151,7 +151,6 @@ generated quantities {
   }
   
   if (compute_mean_PPD) {
-    mean_PPD = 0;
     vector[N[1]] pi0;
     vector[N[2]] pi1;
     // defines eta0, eta1

--- a/src/stan_files/binomial.stan
+++ b/src/stan_files/binomial.stan
@@ -82,7 +82,7 @@ model {
                       regularization, delta, shape, t, p);
 }
 generated quantities {
-  real mean_PPD = negative_infinity();
+  real mean_PPD = compute_mean_PPD ? 0 : negative_infinity();
   real alpha[has_intercept];
   
   if (has_intercept == 1) {
@@ -91,7 +91,6 @@ generated quantities {
   }
   
   if (compute_mean_PPD) {
-    mean_PPD = 0;
     vector[N] pi;
 #include /model/make_eta.stan
     if (t > 0) {

--- a/src/stan_files/binomial.stan
+++ b/src/stan_files/binomial.stan
@@ -82,13 +82,16 @@ model {
                       regularization, delta, shape, t, p);
 }
 generated quantities {
+  real mean_PPD = negative_infinity();
   real alpha[has_intercept];
-  real mean_PPD = 0;
+  
   if (has_intercept == 1) {
     if (dense_X) alpha[1] = gamma[1] - dot_product(xbar, beta);
     else alpha[1] = gamma[1];
   }
-  {
+  
+  if (compute_mean_PPD) {
+    mean_PPD = 0;
     vector[N] pi;
 #include /model/make_eta.stan
     if (t > 0) {

--- a/src/stan_files/continuous.stan
+++ b/src/stan_files/continuous.stan
@@ -220,7 +220,7 @@ model {
                       regularization, delta, shape, t, p);
 }
 generated quantities {
-  real mean_PPD = negative_infinity();
+  real mean_PPD = compute_mean_PPD ? 0 : negative_infinity();
   real alpha[has_intercept];
   real omega_int[has_intercept_z];
   
@@ -233,7 +233,6 @@ generated quantities {
   }
   
   if (compute_mean_PPD) {
-    mean_PPD = 0;
     vector[N] eta_z;
 #include /model/make_eta.stan
     if (t > 0) {

--- a/src/stan_files/continuous.stan
+++ b/src/stan_files/continuous.stan
@@ -220,9 +220,10 @@ model {
                       regularization, delta, shape, t, p);
 }
 generated quantities {
+  real mean_PPD = negative_infinity();
   real alpha[has_intercept];
   real omega_int[has_intercept_z];
-  real mean_PPD = 0;
+  
   if (has_intercept == 1) {
     if (dense_X) alpha[1] = gamma[1] - dot_product(xbar, beta);
     else alpha[1] = gamma[1];
@@ -230,7 +231,9 @@ generated quantities {
   if (has_intercept_z == 1) { 
     omega_int[1] = gamma_z[1] - dot_product(zbar, omega);  // adjust betareg intercept 
   }
-  {
+  
+  if (compute_mean_PPD) {
+    mean_PPD = 0;
     vector[N] eta_z;
 #include /model/make_eta.stan
     if (t > 0) {

--- a/src/stan_files/count.stan
+++ b/src/stan_files/count.stan
@@ -126,13 +126,14 @@ model {
                       regularization, delta, shape, t, p);
 }
 generated quantities {
+  real mean_PPD = negative_infinity();
   real alpha[has_intercept];
-  real mean_PPD = 0;
   if (has_intercept == 1) {
     if (dense_X) alpha[1] = gamma[1] - dot_product(xbar, beta);
     else alpha[1] = gamma[1];
   }
-  {
+  if (compute_mean_PPD) {
+    mean_PPD = 0;
     vector[N] nu;
 #include /model/make_eta.stan
     if (t > 0) {

--- a/src/stan_files/count.stan
+++ b/src/stan_files/count.stan
@@ -126,14 +126,15 @@ model {
                       regularization, delta, shape, t, p);
 }
 generated quantities {
-  real mean_PPD = negative_infinity();
+  real mean_PPD = compute_mean_PPD ? 0 : negative_infinity();
   real alpha[has_intercept];
+  
   if (has_intercept == 1) {
     if (dense_X) alpha[1] = gamma[1] - dot_product(xbar, beta);
     else alpha[1] = gamma[1];
   }
+  
   if (compute_mean_PPD) {
-    mean_PPD = 0;
     vector[N] nu;
 #include /model/make_eta.stan
     if (t > 0) {

--- a/src/stan_files/data/data_glm.stan
+++ b/src/stan_files/data/data_glm.stan
@@ -1,5 +1,6 @@
   // flag indicating whether to draw from the prior
   int<lower=0,upper=1> prior_PD;  // 1 = yes
+  int<lower=0,upper=1> compute_mean_PPD; // 1 = yes
   
   // intercept
   int<lower=0,upper=1> has_intercept;  // 1 = yes


### PR DESCRIPTION
closes #283 

@avehtari @bgoodri 

This PR adds a `mean_PPD` argument to `stan_glm` that defaults to `TRUE` except when `algorithm="optimizing"`:

```r
stan_glm(..., mean_PPD = algorithm != "optimizing")
```

The `print.stanreg` method has also been updated to not print `mean_PPD` information if `mean_PPD` was set to `FALSE` when fitting the model. 


### Changes to Stan programs

In the Stan files used for `stan_glm` a `compute_mean_PPD` flag has been added to the data block via the `data_glm` chunk

```stan
int<lower=0,upper=1> compute_mean_PPD;  // 1 = yes
```

and then in `generated quantities` 

```stan
real mean_PPD = compute_mean_PPD ? 0 : negative_infinity();
...  
if (compute_mean_PPD) {
...
}
```