### PR TITLE
Tidy up prior_summary for stan_jm and stan_mvmer

### DIFF
--- a/R/prior_summary.R
+++ b/R/prior_summary.R
@@ -167,7 +167,7 @@ print.prior_summary.stanreg <- function(x, digits, ...) {
       if (!is.null(x[["prior_intercept"]][[m]]))
         .print_scalar_prior(
           x[["prior_intercept"]][[m]], 
-          txt = paste0(if (M > 1) "\n", "y", m, "|Intercept", if (!sparse) 
+          txt = paste0(if (m > 1) "\n", "y", m, "|Intercept", if (!sparse) 
             " (after predictors centered)"), 
           formatters
         )
@@ -208,7 +208,7 @@ print.prior_summary.stanreg <- function(x, digits, ...) {
       if (!is.null(x[["priorLong_intercept"]][[m]]))
         .print_scalar_prior(
           x[["priorLong_intercept"]][[m]], 
-          txt = paste0(if (M > 1) "\n", "Long", m, "|Intercept", if (!sparse) 
+          txt = paste0(if (m > 1) "\n", "Long", m, "|Intercept", if (!sparse) 
             " (after predictors centered)"), 
           formatters
         )
@@ -401,15 +401,34 @@ used.sparse <- function(x) {
     cat("\n     **adjusted scale =", .f2(p$adjusted_scale))
 }
 .print_covariance_prior <- function(p, txt = "Covariance", formatters = list()) {
-  .f1 <- formatters[[1]]
-  p$regularization <- .format_pars(p$regularization, .f1)
-  p$concentration <- .format_pars(p$concentration, .f1)
-  p$shape <- .format_pars(p$shape, .f1)
-  p$scale <- .format_pars(p$scale, .f1)
-  cat(paste0("\n", txt, "\n ~"),
-      paste0(p$dist, "(",  
-             "reg. = ", .f1(p$regularization),
-             ", conc. = ", .f1(p$concentration), ", shape = ", .f1(p$shape),
-             ", scale = ", .f1(p$scale), ")")
-  )
+  if (p$dist == "decov") {
+    .f1 <- formatters[[1]]
+    p$regularization <- .format_pars(p$regularization, .f1)
+    p$concentration <- .format_pars(p$concentration, .f1)
+    p$shape <- .format_pars(p$shape, .f1)
+    p$scale <- .format_pars(p$scale, .f1)
+    cat(paste0("\n", txt, "\n ~"),
+        paste0(p$dist, "(",  
+               "reg. = ",    .f1(p$regularization),
+               ", conc. = ", .f1(p$concentration), 
+               ", shape = ", .f1(p$shape),
+               ", scale = ", .f1(p$scale), ")")
+    )    
+  } else if (p$dist == "lkj") {
+    .f1 <- formatters[[1]]
+    .f2 <- formatters[[2]]
+    p$regularization <- .format_pars(p$regularization, .f1)
+    p$df <- .format_pars(p$df, .f1)
+    p$scale <- .format_pars(p$scale, .f1)
+    if (!is.null(p$adjusted_scale))
+      p$adjusted_scale <- .format_pars(p$adjusted_scale, .f2)
+    cat(paste0("\n", txt, "\n ~"),
+        paste0(p$dist, "(",  
+               "reg. = ",    .f1(p$regularization),
+               ", df = ",    .f1(p$df), 
+               ", scale = ", .f1(p$scale), ")")
+    )    
+    if (!is.null(p$adjusted_scale))
+      cat("\n     **adjusted scale =", .f2(p$adjusted_scale))
+  }
 }

--- a/R/stan_jm.fit.R
+++ b/R/stan_jm.fit.R
@@ -862,6 +862,8 @@ stan_jm.fit <- function(formulaLong = NULL, dataLong = NULL, formulaEvent = NULL
     if (is_jm) user_priorEvent_aux = e_user_prior_aux_stuff,
     if (is_jm) user_priorEvent_assoc = e_user_prior_assoc_stuff,
     user_prior_covariance = prior_covariance,
+    b_user_prior_stuff = b_user_prior_stuff,
+    b_prior_stuff = b_prior_stuff,
     y_has_intercept = fetch_(y_mod, "x", "has_intercept"),
     y_has_predictors = fetch_(y_mod, "x", "K") > 0,
     if (is_jm) e_has_intercept = standata$e_has_intercept,
@@ -875,7 +877,8 @@ stan_jm.fit <- function(formulaLong = NULL, dataLong = NULL, formulaEvent = NULL
     if (is_jm) adjusted_priorEvent_aux_scale = e_prior_aux_stuff$prior_scale,
     if (is_jm) adjusted_priorEvent_assoc_scale = e_prior_assoc_stuff$prior_scale,
     family = family, 
-    if (is_jm) basehaz = basehaz
+    if (is_jm) basehaz = basehaz,
+    stub_for_names = if (is_jm) "Long" else "y"
   )  
   
   #-----------


### PR DESCRIPTION
Some aspects of the `lkj()` prior were not getting returned in the `prior.info` element of stan_jm/mvmer objects. They should be included now. The printing of the `lkj()` when `prior_summary` is called should now be more comprehensive; before it was missing the adjusted scales and df for the student-t component of the `lkj()` prior (i.e. the student-t prior on the SDs of the random effects).

The `stan_mvmer` objects also needed a small fix. The elements of their `prior.info` were named "priorLong", "priorLong_intercept", etc, as in joint models. I needed to remove the "Long" from these names so that they printed correctly when `prior_summary()` was called on a `stan_mvmer` object.