### PR TITLE
fix kfold to work when folds given and K!=10

### DIFF
--- a/R/loo.R
+++ b/R/loo.R
@@ -391,6 +391,7 @@ kfold <- function(x, K = 10, save_fits = FALSE, folds = NULL) {
   if (is.null(folds)) {
     folds <- loo::kfold_split_random(K = K, N = N)
   } else {
+    K <- length(unique(folds))
     stopifnot(
       length(folds) == N,
       all(folds == as.integer(folds)),


### PR DESCRIPTION
Fix kfold to work if folds are given but the number of folds in folds is different from 10 (the default value for K in kfold function)