### PR TITLE
bugfix/stanjm assoc data interaction

### DIFF
--- a/src/stan_files/model/assoc_evaluate.stan
+++ b/src/stan_files/model/assoc_evaluate.stan
@@ -37,7 +37,6 @@
           mark += 1;
           e_eta_q += a_beta[mark] * (val - a_xbar[mark]);
         }
-        mark2 += 1; // count even if assoc type isn't used
         if (has_assoc[9,m] == 1) { // etavalue*data
           int J = a_K_data[mark2];
           int j_shift = (mark2 == 1) ? 0 : sum(a_K_data[1:(mark2-1)]);

--- a/src/stan_files/model/assoc_evaluate.stan
+++ b/src/stan_files/model/assoc_evaluate.stan
@@ -40,7 +40,7 @@
         mark2 += 1; // count even if assoc type isn't used
         if (has_assoc[9,m] == 1) { // etavalue*data
           int J = a_K_data[mark2];
-            int j_shift = (mark2 == 1) ? 0 : sum(a_K_data[1:(mark2-1)]);
+          int j_shift = (mark2 == 1) ? 0 : sum(a_K_data[1:(mark2-1)]);
           for (j in 1:J) {
             vector[nrow_e_Xq] val;
             int sel = j_shift + j;
@@ -89,66 +89,66 @@
 
       //----- etaslope and any interactions
 
-            mark2 += 1;
-            if ((has_assoc[2,m] == 1) || (has_assoc[10,m] == 1)) {
+      mark2 += 1;
+      if ((has_assoc[2,m] == 1) || (has_assoc[10,m] == 1)) {
 
-                // declare and define etaslope at quadpoints for submodel m
-                vector[nrow_y_Xq[m]] dydt_eta_q;
-                if (m == 1) {
-                    int bMat1_colshift = 0;
-                    int bMat2_colshift = 0;
-                    dydt_eta_q = evaluate_eta(y1_xq_eps, y1_z1q_eps, y1_z2q_eps,
-                                              y1_z1q_id_eps, y1_z2q_id_eps,
-                                              yGamma1, yBeta1, bMat1, bMat2,
-                                              bMat1_colshift, bMat2_colshift, 0);
-                }
-                else if (m == 2) {
-                    int bMat1_colshift = bK1_len[1];
-                    int bMat2_colshift = bK2_len[1];
-                    dydt_eta_q = evaluate_eta(y2_xq_eps, y2_z1q_eps, y2_z2q_eps,
-                                              y2_z1q_id_eps, y2_z2q_id_eps,
-                                              yGamma2, yBeta2, bMat1, bMat2,
-                                              bMat1_colshift, bMat2_colshift, 0);
-                }
-                else if (m == 3) {
-                    int bMat1_colshift = sum(bK1_len[1:2]);
-                    int bMat2_colshift = sum(bK2_len[1:2]);
-                    dydt_eta_q = evaluate_eta(y3_xq_eps, y3_z1q_eps, y3_z2q_eps,
-                                              y3_z1q_id_eps, y3_z2q_id_eps,
-                                              yGamma3, yBeta3, bMat1, bMat2,
-                                              bMat1_colshift, bMat2_colshift, 0);
-                }
+        // declare and define etaslope at quadpoints for submodel m
+        vector[nrow_y_Xq[m]] dydt_eta_q;
+        if (m == 1) {
+          int bMat1_colshift = 0;
+          int bMat2_colshift = 0;
+          dydt_eta_q = evaluate_eta(y1_xq_eps, y1_z1q_eps, y1_z2q_eps,
+                                    y1_z1q_id_eps, y1_z2q_id_eps,
+                                    yGamma1, yBeta1, bMat1, bMat2,
+                                    bMat1_colshift, bMat2_colshift, 0);
+        }
+        else if (m == 2) {
+          int bMat1_colshift = bK1_len[1];
+          int bMat2_colshift = bK2_len[1];
+          dydt_eta_q = evaluate_eta(y2_xq_eps, y2_z1q_eps, y2_z2q_eps,
+                                    y2_z1q_id_eps, y2_z2q_id_eps,
+                                    yGamma2, yBeta2, bMat1, bMat2,
+                                    bMat1_colshift, bMat2_colshift, 0);
+        }
+        else if (m == 3) {
+          int bMat1_colshift = sum(bK1_len[1:2]);
+          int bMat2_colshift = sum(bK2_len[1:2]);
+          dydt_eta_q = evaluate_eta(y3_xq_eps, y3_z1q_eps, y3_z2q_eps,
+                                    y3_z1q_id_eps, y3_z2q_id_eps,
+                                    yGamma3, yBeta3, bMat1, bMat2,
+                                    bMat1_colshift, bMat2_colshift, 0);
+        }
 
         // add etaslope and any interactions to event submodel eta
-                if (has_assoc[2,m] == 1) { // etaslope
-                    vector[nrow_e_Xq] val;
-                    if (has_grp[m] == 0) {
-                        val = dydt_eta_q;
-                    }
-                    else {
-                        val = collapse_within_groups(dydt_eta_q, grp_idx, grp_assoc);
-                    }
-                    mark += 1;
-                    e_eta_q += a_beta[mark] * (val - a_xbar[mark]);
-                }
-                if (has_assoc[10,m] == 1) { // etaslope*data
-                    int J = a_K_data[mark2];
-                    int j_shift = (mark2 == 1) ? 0 : sum(a_K_data[1:(mark2-1)]);
-                    for (j in 1:J) {
-                        vector[nrow_e_Xq] val;
-                        int sel = j_shift + j;
-                        if (has_grp[m] == 0) {
-                            val = dydt_eta_q .* y_Xq_data[idx_q[m,1]:idx_q[m,2], sel];
-                        }
-                        else {
-                            val = collapse_within_groups(
-                                dydt_eta_q .* y_Xq_data[idx_q[m,1]:idx_q[m,2], sel],
-                                grp_idx, grp_assoc);
-                        }
-                        mark += 1;
-                        e_eta_q += a_beta[mark] * (val - a_xbar[mark]);
-                    }
-                }
+        if (has_assoc[2,m] == 1) { // etaslope
+          vector[nrow_e_Xq] val;
+          if (has_grp[m] == 0) {
+            val = dydt_eta_q;
+          }
+          else {
+            val = collapse_within_groups(dydt_eta_q, grp_idx, grp_assoc);
+          }
+          mark += 1;
+          e_eta_q += a_beta[mark] * (val - a_xbar[mark]);
+        }
+        if (has_assoc[10,m] == 1) { // etaslope*data
+          int J = a_K_data[mark2];
+          int j_shift = (mark2 == 1) ? 0 : sum(a_K_data[1:(mark2-1)]);
+          for (j in 1:J) {
+            vector[nrow_e_Xq] val;
+            int sel = j_shift + j;
+            if (has_grp[m] == 0) {
+              val = dydt_eta_q .* y_Xq_data[idx_q[m,1]:idx_q[m,2], sel];
+            }
+            else {
+              val = collapse_within_groups(
+                      dydt_eta_q .* y_Xq_data[idx_q[m,1]:idx_q[m,2], sel],
+                      grp_idx, grp_assoc);
+            }
+            mark += 1;
+            e_eta_q += a_beta[mark] * (val - a_xbar[mark]);
+          }
+        }
       }
 
       //----- etaauc
@@ -157,33 +157,33 @@
       if (has_assoc[3,m] == 1) { // etaauc
         vector[nrow_y_Xq_auc] eta_auc_tmp; // eta at all auc quadpoints (for submodel m)
         vector[nrow_y_Xq[m]] val; // eta following summation over auc quadpoints
-				if (m == 1) {
-					int bMat1_colshift = 0;
-					int bMat2_colshift = 0;
-					eta_auc_tmp = evaluate_eta(y1_xq_auc, y1_z1q_auc, y1_z2q_auc, 
-																 y1_z1q_id_auc, y1_z2q_id_auc, 
-																 yGamma1, yBeta1, bMat1, bMat2, 
-																 bMat1_colshift, bMat2_colshift, 
-																 intercept_type[1]);
-				}
-				else if (m == 2) {
-					int bMat1_colshift = bK1_len[1];
-					int bMat2_colshift = bK2_len[1];
-					eta_auc_tmp = evaluate_eta(y2_xq_auc, y2_z1q_auc, y2_z2q_auc, 
-																 y2_z1q_id_auc, y2_z2q_id_auc, 
-																 yGamma2, yBeta2, bMat1, bMat2, 
-																 bMat1_colshift, bMat2_colshift, 
-																 intercept_type[2]);
-				}
-				else if (m == 3) {
-					int bMat1_colshift = sum(bK1_len[1:2]);
-					int bMat2_colshift = sum(bK2_len[1:2]);
-					eta_auc_tmp = evaluate_eta(y3_xq_auc, y3_z1q_auc, y3_z2q_auc, 
-																 y3_z1q_id_auc, y3_z2q_id_auc, 
-																 yGamma3, yBeta3, bMat1, bMat2, 
-																 bMat1_colshift, bMat2_colshift, 
-																 intercept_type[3]);
-				}				
+        if (m == 1) {
+          int bMat1_colshift = 0;
+          int bMat2_colshift = 0;
+          eta_auc_tmp = evaluate_eta(y1_xq_auc, y1_z1q_auc, y1_z2q_auc,
+                                     y1_z1q_id_auc, y1_z2q_id_auc,
+                                     yGamma1, yBeta1, bMat1, bMat2,
+                                     bMat1_colshift, bMat2_colshift,
+                                     intercept_type[1]);
+        }
+        else if (m == 2) {
+          int bMat1_colshift = bK1_len[1];
+          int bMat2_colshift = bK2_len[1];
+          eta_auc_tmp = evaluate_eta(y2_xq_auc, y2_z1q_auc, y2_z2q_auc,
+                                     y2_z1q_id_auc, y2_z2q_id_auc,
+                                     yGamma2, yBeta2, bMat1, bMat2,
+                                     bMat1_colshift, bMat2_colshift,
+                                     intercept_type[2]);
+        }
+        else if (m == 3) {
+          int bMat1_colshift = sum(bK1_len[1:2]);
+          int bMat2_colshift = sum(bK2_len[1:2]);
+          eta_auc_tmp = evaluate_eta(y3_xq_auc, y3_z1q_auc, y3_z2q_auc,
+                                     y3_z1q_id_auc, y3_z2q_id_auc,
+                                     yGamma3, yBeta3, bMat1, bMat2,
+                                     bMat1_colshift, bMat2_colshift,
+                                     intercept_type[3]);
+        }
         mark += 1;
         for (r in 1:nrow_y_Xq[m]) {
           vector[auc_qnodes] val_tmp;
@@ -281,35 +281,35 @@
       // add muauc to event submodel eta
       if (has_assoc[6,m] == 1) { // muauc
         vector[nrow_y_Xq_auc] eta_auc_tmp; // eta at all auc quadpoints (for submodel m)
-        vector[nrow_y_Xq_auc] mu_auc_tmp; // mu at all auc quadpoints (for submodel m)  
-        vector[nrow_y_Xq[m]] val; // mu following summation over auc quadpoints 
-				if (m == 1) {
-					int bMat1_colshift = 0;
-					int bMat2_colshift = 0;
-					eta_auc_tmp = evaluate_eta(y1_xq_auc, y1_z1q_auc, y1_z2q_auc, 
-																 y1_z1q_id_auc, y1_z2q_id_auc, 
-																 yGamma1, yBeta1, bMat1, bMat2, 
-																 bMat1_colshift, bMat2_colshift, 
-																 intercept_type[1]);
-				}
-				else if (m == 2) {
-					int bMat1_colshift = bK1_len[1];
-					int bMat2_colshift = bK2_len[1];
-					eta_auc_tmp = evaluate_eta(y2_xq_auc, y2_z1q_auc, y2_z2q_auc, 
-																 y2_z1q_id_auc, y2_z2q_id_auc, 
-																 yGamma2, yBeta2, bMat1, bMat2, 
-																 bMat1_colshift, bMat2_colshift, 
-																 intercept_type[2]);
-				}
-				else if (m == 3) {
-					int bMat1_colshift = sum(bK1_len[1:2]);
-					int bMat2_colshift = sum(bK2_len[1:2]);
-					eta_auc_tmp = evaluate_eta(y3_xq_auc, y3_z1q_auc, y3_z2q_auc, 
-																 y3_z1q_id_auc, y3_z2q_id_auc, 
-																 yGamma3, yBeta3, bMat1, bMat2, 
-																 bMat1_colshift, bMat2_colshift, 
-																 intercept_type[3]);
-				}				
+        vector[nrow_y_Xq_auc] mu_auc_tmp; // mu at all auc quadpoints (for submodel m)
+        vector[nrow_y_Xq[m]] val; // mu following summation over auc quadpoints
+        if (m == 1) {
+          int bMat1_colshift = 0;
+          int bMat2_colshift = 0;
+          eta_auc_tmp = evaluate_eta(y1_xq_auc, y1_z1q_auc, y1_z2q_auc,
+                                     y1_z1q_id_auc, y1_z2q_id_auc,
+                                     yGamma1, yBeta1, bMat1, bMat2,
+                                     bMat1_colshift, bMat2_colshift,
+                                     intercept_type[1]);
+        }
+        else if (m == 2) {
+          int bMat1_colshift = bK1_len[1];
+          int bMat2_colshift = bK2_len[1];
+          eta_auc_tmp = evaluate_eta(y2_xq_auc, y2_z1q_auc, y2_z2q_auc,
+                                     y2_z1q_id_auc, y2_z2q_id_auc,
+                                     yGamma2, yBeta2, bMat1, bMat2,
+                                     bMat1_colshift, bMat2_colshift,
+                                     intercept_type[2]);
+        }
+        else if (m == 3) {
+          int bMat1_colshift = sum(bK1_len[1:2]);
+          int bMat2_colshift = sum(bK2_len[1:2]);
+          eta_auc_tmp = evaluate_eta(y3_xq_auc, y3_z1q_auc, y3_z2q_auc,
+                                     y3_z1q_id_auc, y3_z2q_id_auc,
+                                     yGamma3, yBeta3, bMat1, bMat2,
+                                     bMat1_colshift, bMat2_colshift,
+                                     intercept_type[3]);
+        }
         mu_auc_tmp = evaluate_mu(eta_auc_tmp, family[m], link[m]);
         mark += 1;
         for (r in 1:nrow_y_Xq[m]) {


### PR DESCRIPTION
Closes #342. This fixes a serious bug in the `etavalue_data` and `etaslope_data` association structures for `stan_jm`.