### PR TITLE
Don't require LHS of formula if prior_PD=TRUE (for some modeling functions)

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -683,12 +683,15 @@ check_reTrms <- function(reTrms) {
 }
 
 #' @importFrom lme4 glmerControl
-make_glmerControl <- function(...) {
+# @param checkLHS throw error if formula LHS is missing? (relevant if prior_PD is TRUE)
+make_glmerControl <- function(..., checkLHS = TRUE) {
   glmerControl(check.nlev.gtreq.5 = "ignore",
                check.nlev.gtr.1 = "stop",
                check.nobs.vs.rankZ = "ignore",
                check.nobs.vs.nlev = "ignore",
-               check.nobs.vs.nRE = "ignore", ...)  
+               check.nobs.vs.nRE = "ignore", 
+               check.formula.LHS = if (checkLHS) "stop" else "ignore",
+               ...)  
 }
 
 # Check if a fitted model (stanreg object) has weights

--- a/R/misc.R
+++ b/R/misc.R
@@ -334,6 +334,19 @@ validate_glm_formula <- function(f) {
 }
 
 
+# Check if model formula has something on the LHS of ~
+# @param f Model formula
+# @return FALSE if there is no outcome on the LHS of the formula
+has_outcome_variable <- function(f) {
+  tt <- terms(as.formula(f))
+  if (attr(tt, "response") == 0) {
+    return(FALSE)
+  } else {
+    return(TRUE)
+  }
+}
+
+
 # Check if any variables in a model frame are constants
 # (the exception is that a constant variable of all 1's is allowed)
 # 

--- a/R/stan_betareg.R
+++ b/R/stan_betareg.R
@@ -127,8 +127,12 @@ stan_betareg <-
            adapt_delta = NULL,
            QR = FALSE) {
     
-    if (!requireNamespace("betareg", quietly = TRUE))
+    if (!requireNamespace("betareg", quietly = TRUE)) {
       stop("Please install the betareg package before using 'stan_betareg'.")
+    }
+    if (!has_outcome_variable(formula)) {
+      stop("LHS of formula must be specified.")
+    }
     
     mc <- match.call(expand.dots = FALSE)
     data <- validate_data(data, if_missing = environment(formula))

--- a/R/stan_biglm.fit.R
+++ b/R/stan_biglm.fit.R
@@ -41,11 +41,18 @@
 #'                        # the next line is only to make the example go fast
 #'                        chains = 1, iter = 500, seed = 12345)
 #' cbind(lm = b, stan_lm = rstan::get_posterior_mean(post)[13:15,]) # shrunk
+#' 
 stan_biglm.fit <- function(b, R, SSR, N, xbar, ybar, s_y, has_intercept = TRUE, ...,
                            prior = R2(stop("'location' must be specified")), 
                            prior_intercept = NULL, prior_PD = FALSE, 
                            algorithm = c("sampling", "meanfield", "fullrank"),
                            adapt_delta = NULL) {
+  
+  if (prior_PD && is.null(prior_intercept)) {
+    msg <- "The default flat prior on the intercept is not recommended with when 'prior_PD' is TRUE."
+    warning(msg, call. = FALSE, immediate. = TRUE)
+    warning(msg, call. = FALSE, immediate. = FALSE)
+  }
   
   J <- 1L
   N <- array(N, c(J))

--- a/R/stan_biglm.fit.R
+++ b/R/stan_biglm.fit.R
@@ -49,7 +49,7 @@ stan_biglm.fit <- function(b, R, SSR, N, xbar, ybar, s_y, has_intercept = TRUE, 
                            adapt_delta = NULL) {
   
   if (prior_PD && is.null(prior_intercept)) {
-    msg <- "The default flat prior on the intercept is not recommended with when 'prior_PD' is TRUE."
+    msg <- "The default flat prior on the intercept is not recommended when 'prior_PD' is TRUE."
     warning(msg, call. = FALSE, immediate. = TRUE)
     warning(msg, call. = FALSE, immediate. = FALSE)
   }

--- a/R/stan_glm.R
+++ b/R/stan_glm.R
@@ -235,6 +235,11 @@ stan_glm <-
     Y <- cbind(y1, y0 = weights - y1)
     weights <- double(0)
   }
+  
+  if (prior_PD) {
+    # can result in errors (e.g. from poisson) if draws from prior are weird
+    mean_PPD <- FALSE
+  }
 
   stanfit <- stan_glm.fit(
     x = X,

--- a/R/stan_glm.R
+++ b/R/stan_glm.R
@@ -260,7 +260,7 @@ stan_glm <-
   
   sel <- apply(X, 2L, function(x) !all(x == 1) && length(unique(x)) < 2)
   X <- X[ , !sel, drop = FALSE]  
-  
+
   fit <- nlist(stanfit, algorithm, family, formula, data, offset, weights,
                x = X, y = Y, model = mf,  terms = mt, call, 
                na.action = attr(mf, "na.action"), 

--- a/R/stan_glm.fit.R
+++ b/R/stan_glm.fit.R
@@ -214,7 +214,7 @@ stan_glm.fit <-
            "the model must have an intercept.")
   }
   
-  # allow prior_PD even if y is NULL
+  # allow prior_PD even if no y variable
   if (is.null(y)) {
     if (!prior_PD) {
       stop("Outcome variable must be specified if 'prior_PD' is not TRUE.")
@@ -825,6 +825,8 @@ validate_glm_outcome_support <- function(y, family) {
 }
 
 # Generate fake y variable to use if prior_PD and no y is specified
+# @param N number of observations
+# @param family family object
 fake_y_for_prior_PD <- function(N, family) {
   fam <- family$family
   if (is.gaussian(fam)) {

--- a/R/stan_glm.fit.R
+++ b/R/stan_glm.fit.R
@@ -220,6 +220,10 @@ stan_glm.fit <-
       stop("Outcome variable must be specified if 'prior_PD' is not TRUE.")
     } else {
       y <- fake_y_for_prior_PD(N = NROW(x), family = family)
+      if (is_gaussian && 
+          (prior_autoscale || prior_autoscale_for_intercept || prior_autoscale_for_aux)) {
+        message("'y' not specified, will assume sd(y)=1 when calculating scaled prior(s). ")
+      }
     }
   }
   

--- a/R/stan_glm.fit.R
+++ b/R/stan_glm.fit.R
@@ -214,6 +214,16 @@ stan_glm.fit <-
            "the model must have an intercept.")
   }
   
+  # allow prior_PD even if y is NULL
+  if (is.null(y)) {
+    if (!prior_PD) {
+      stop("Outcome variable must be specified if 'prior_PD' is not TRUE.")
+    } else {
+      y <- fake_y_for_prior_PD(N = NROW(x), family = family)
+    }
+  }
+  
+  
   if (is_gaussian) {
     ss <- sd(y)
     if (prior_dist > 0L && prior_autoscale) 
@@ -753,6 +763,10 @@ stan_family_number <- function(famname) {
 # @return y (possibly slightly modified) unless an error is thrown
 #
 validate_glm_outcome_support <- function(y, family) {
+  if (is.null(y)) {
+    return(y)
+  }
+  
   .is_count <- function(x) {
     all(x >= 0) && all(abs(x - round(x)) < .Machine$double.eps^0.5)
   }
@@ -808,6 +822,23 @@ validate_glm_outcome_support <- function(y, family) {
   }
   
   return(y)
+}
+
+# Generate fake y variable to use if prior_PD and no y is specified
+fake_y_for_prior_PD <- function(N, family) {
+  fam <- family$family
+  if (is.gaussian(fam)) {
+    # if prior autoscaling is on then the value of sd(y) matters
+    # generate a fake y so that sd(y) is 1
+    fake_y <- as.vector(scale(rnorm(N)))
+  } else if (is.binomial(fam) || is.poisson(fam) || is.nb(fam)) {
+    # valid for all discrete cases
+    fake_y <- rep_len(c(0, 1), N)
+  } else {
+    # valid for gamma, inverse gaussian, beta 
+    fake_y <- runif(N)
+  }
+  return(fake_y)
 }
 
 

--- a/R/stan_lm.fit.R
+++ b/R/stan_lm.fit.R
@@ -39,6 +39,15 @@ stan_lm.wfit <- function(x, y, w, offset = NULL, singular.ok = TRUE, ...,
     stop("stan_lm with more predictors than data points is not yet enabled.", 
          call. = FALSE)
   
+  # allow prior_PD even if no y variable
+  if (is.null(y)) {
+    if (!prior_PD) {
+      stop("Outcome variable must be specified if 'prior_PD' is not TRUE.")
+    } else {
+      y <- fake_y_for_prior_PD(N = NROW(x), family = gaussian())
+    }
+  }
+  
   xbar <- colMeans(x)
   x <- sweep(x, 2L, xbar, FUN = "-")
   ybar <- mean(y)

--- a/R/stan_nlmer.R
+++ b/R/stan_nlmer.R
@@ -105,7 +105,7 @@ stan_nlmer <-
            sparse = FALSE) {
 
   if (!has_outcome_variable(formula[[2]])) {
-    stop("LHS of formula must be specified for 'stan_nlmer.'")
+    stop("LHS of formula must be specified.")
   }
   f <- as.character(formula[-3])
   SSfunctions <- grep("^SS[[:lower:]]+", ls("package:stats"), value = TRUE) 

--- a/R/stan_nlmer.R
+++ b/R/stan_nlmer.R
@@ -103,13 +103,17 @@ stan_nlmer <-
            adapt_delta = NULL,
            QR = FALSE,
            sparse = FALSE) {
-    
+
+  if (!has_outcome_variable(formula[[2]])) {
+    stop("LHS of formula must be specified for 'stan_nlmer.'")
+  }
   f <- as.character(formula[-3])
   SSfunctions <- grep("^SS[[:lower:]]+", ls("package:stats"), value = TRUE) 
   SSfun <- sapply(SSfunctions, function(ss) 
     grepl(paste0(ss, "("), x = f[2], fixed = TRUE))
-  if (!any(SSfun))
+  if (!any(SSfun)) {
     stop("'stan_nlmer' requires a named self-starting nonlinear function.")
+  }
   SSfun <- which(SSfun)
   SSfun_char <- names(SSfun)
   
@@ -148,7 +152,10 @@ stan_nlmer <-
                           prior_aux = prior_aux, prior_PD = prior_PD, 
                           algorithm = algorithm, adapt_delta = adapt_delta,
                           group = nlf$reTrms, QR = QR, sparse = sparse, ...)
-  if (algorithm != "optimizing" && !is(stanfit, "stanfit")) return(stanfit)
+  if (algorithm != "optimizing" && !is(stanfit, "stanfit")) {
+    return(stanfit)
+  }
+  
   if (SSfun_char == "SSfpl") { # SSfun = 6
     stanfit@sim$samples <- lapply(stanfit@sim$samples, FUN = function(x) {
       x[[4L]] <- exp(x[[4L]])


### PR DESCRIPTION
closes #337

This PR allows formulas with no LHS when `prior_PD=TRUE`. This is implemented for `stan_glm`, `stan_[g]lmer`, and `stan_lm` only (although I don't think it makes as much sense for `stan_lm` given the prior). 

It does this by generating fake outcome variables which allows the Stan code to run (it needs N values of y even if not conditioning on them). 

For Gaussian models the fake outcome has SD of 1, which essentially disables prior autoscaling even if autoscale is left at TRUE. Because the default priors do autoscaling,  it therefore matters whether y is specified or not when `prior_PD=TRUE` unless autoscale=FALSE for all priors (including intercept and aux). 

#### Example

These give different results because of the default prior autoscaling:

```r
# don't specify LHS (basically the same as turning off autoscaling)
fit1 <- stan_glm( ~ wt + qsec + am, data = mtcars, prior_PD = TRUE, refresh = 0)

# specify LHS (much wider priors because sd(mpg) is big)
fit2 <- stan_glm(mpg ~ wt + qsec + am, data = mtcars, prior_PD = TRUE, refresh = 0)
```

These should be the same because autoscaling is off: 
```r
# don't specify LHS
fit3 <- stan_glm(
  ~ wt + qsec + am,
  data = mtcars,
  prior = normal(0, 1, autoscale = FALSE),
  prior_intercept = normal(0, 1, autoscale = FALSE),
  prior_aux = normal(0, 1, autoscale = FALSE),
  refresh = 0,
  prior_PD = TRUE
)

# specify LHS
fit4 <- stan_glm(
  mpg ~ wt + qsec + am,
  data = mtcars,
  prior = normal(0, 1, autoscale = FALSE),
  prior_intercept = normal(0, 1, autoscale = FALSE),
  prior_aux = normal(0, 1, autoscale = FALSE),
  refresh = 0,
  prior_PD = TRUE
)
```
