### PR TITLE
speedup with normal_id_glm when applicable

### DIFF
--- a/src/stan_files/continuous.stan
+++ b/src/stan_files/continuous.stan
@@ -74,6 +74,10 @@ transformed data {
                    prior_PD == 0 && dense_X && N > 2 && len_y >= (has_intercept + K + K_smooth);
   vector[can_do_OLS ? has_intercept + K + K_smooth : 0] OLS;
   matrix[can_do_OLS ? has_intercept + K + K_smooth : 0, can_do_OLS ? has_intercept + K + K_smooth : 0] XtX;
+  int can_do_normalidglm = family == 1 && link == 1 && SSfun == 0 && has_offset == 0 &&
+                           t == 0 && prior_PD == 0 && dense_X &&
+	                   len_y < (has_intercept + K + K_smooth);
+  matrix[can_do_normalidglm ? N : 0, can_do_normalidglm ? K + K_smooth : 0] XS;
   real SSR = not_a_number();
   // defines hs, len_z_T, len_var_group, delta, is_continuous, pos
 #include /tdata/tdata_glm.stan
@@ -92,6 +96,9 @@ transformed data {
     XtX = crossprod(X_);
     OLS = mdivide_left_spd(XtX, X_' * y);
     SSR = dot_self(y - X_ * OLS);
+  }
+  if (can_do_normalidglm) {
+    XS = K_smooth > 0 ? append_col(X[1], S) : X[1];
   }
 }
 parameters {
@@ -144,6 +151,9 @@ model {
                                               (K_smooth > 0 ? append_row(beta, beta_smooth) : beta)) : 
                                               (K_smooth > 0 ? append_row(beta, beta_smooth) : beta);
     target += ll_mvn_ols(coeff, OLS, XtX, SSR, aux, N);
+  } else if (can_do_normalidglm) {
+    vector[K + K_smooth] coeff = K_smooth > 0 ? append_row(beta, beta_smooth) : beta;
+    target += normal_id_glm_lpdf(y | XS, has_intercept ? gamma[1] : 0.0, coeff, aux);
   } else if (prior_PD == 0) {
     vector[link_phi > 0 ? N : 0] eta_z; // beta regression linear predictor for phi
 #include /model/make_eta.stan


### PR DESCRIPTION
Use normal_id_glm_lpdf when applicable. These are the same cases as for can_do_OLS, but with n<K+K_smooth. At the edge cases when n is just below or above, normal_id_glm_lpdf is 2x faster than OLS trick and 4x faster than the default way.