### PR TITLE
allow all zeros or all ones with bernoulli

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -348,14 +348,18 @@ has_outcome_variable <- function(f) {
 
 
 # Check if any variables in a model frame are constants
-# (the exception is that a constant variable of all 1's is allowed)
+#
+# exceptions: constant variable of all 1's is allowed and outcomes with all 0s
+# or 1s are allowed (e.g., for binomial models)
 # 
 # @param mf A model frame or model matrix
 # @return If no constant variables are found mf is returned, otherwise an error
 #   is thrown.
 check_constant_vars <- function(mf) {
-  # don't check if columns are constant for binomial
-  mf1 <- if (NCOL(mf[, 1]) == 2) mf[, -1, drop=FALSE] else mf
+  mf1 <- mf
+  if (NCOL(mf[, 1]) == 2 || all(mf[, 1] %in% c(0, 1))) {
+    mf1 <- mf[, -1, drop=FALSE] 
+  }
   
   lu1 <- function(x) !all(x == 1) && length(unique(x)) == 1
   nocheck <- c("(weights)", "(offset)", "(Intercept)")

--- a/src/stan_files/bernoulli.stan
+++ b/src/stan_files/bernoulli.stan
@@ -9,7 +9,7 @@ functions {
 data {
   // dimensions
   int<lower=0> K;        // number of predictors
-  int<lower=1> N[2];     // number of observations where y = 0 and y = 1 respectively
+  int<lower=0> N[2];     // number of observations where y = 0 and y = 1 respectively
   vector[K] xbar;        // vector of column-means of rbind(X0, X1)
   int<lower=0,upper=1> dense_X; // flag for dense vs. sparse
   matrix[N[1],K] X0[dense_X];   // centered (by xbar) predictor matrix | y = 0


### PR DESCRIPTION
This PR makes it possible to fit bernoulli models with stan_glm and and stan_glmer where the outcome is all zeros or all ones, e.g. 

```r
d <- data.frame(y = rep(0, 50))
fit <- stan_glm(y ~ 1, data = d, family = "binomial")
```

I had to modify the data block of the Stan program to not require `lower=1`, but as far as I can tell that's the only line of the Stan program that needed changing?