### PR TITLE
Fix bug in bayes_R2() for binomial family with bernoulli trials

### DIFF
--- a/R/bayes_R2.R
+++ b/R/bayes_R2.R
@@ -58,7 +58,7 @@ bayes_R2.stanreg <- function(object, ..., re.form = NULL) {
         sigma2 <- rowMeans(tmp * (1 - mu_pred))
         mu_pred <- tmp
       } else {
-        sigma2 <- rowMeans(mu_pred * (1 - mu_pred) * trials_mat)
+        sigma2 <- rowMeans(mu_pred * (1 - mu_pred))
       }
     } else {
       sigma2 <- drop(as.matrix(object, pars = "sigma"))^2


### PR DESCRIPTION
This closes #376, fixing a bug introduced in 9ff7f71.

Note that there exist no tests for any of these functions, and the handling of `y` in the binomial case is slightly different in `loo_R2`, where it's also checked if it's a factor.