### PR TITLE
Remove hardcoded number of iterations in posterior_vs_prior()

### DIFF
--- a/R/posterior_vs_prior.R
+++ b/R/posterior_vs_prior.R
@@ -149,7 +149,6 @@ posterior_vs_prior.stanreg <-
         object,
         prior_PD = TRUE,
         refresh = -1,
-        iter = 2000,
         chains = 2
       ))
     )


### PR DESCRIPTION
This allows the following examples to run as expected (see #383):

```
x = rnorm(100)
y = rpois(100, exp(x))
d = data.frame(x = x, y = y)

glm_4000_2000 <- stan_glm(y ~ x, data = d, iter = 4000, warmup = 2000)
posterior_vs_prior(glm_4000_2000)

glm_6000_3000 <- stan_glm(y ~ x, data = d, iter = 6000, warmup = 3000)
posterior_vs_prior(glm_6000_3000)
```