### PR TITLE
Bugfix for glms with only intercept

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: rstanarm
 Type: Package
 Title: Bayesian Applied Regression Modeling via Stan
-Version: 2.19.2
-Date: 2019-10-01
+Version: 2.19.3
+Date: 2019-10-10
 Encoding: UTF-8
 Authors@R: c(person("Jonah", "Gabry", email = "jsg2201@columbia.edu", role = "aut"),
              person("Imad", "Ali", role = "ctb"),

--- a/src/stan_files/bernoulli.stan
+++ b/src/stan_files/bernoulli.stan
@@ -76,7 +76,7 @@ transformed data {
   int<lower=0> failures[clogit ? J : 0];
   int<lower=0> observations[clogit ? J : 0];
 
-  int can_do_bernoullilogitglm = K != 0 && // remove after rstan includes this Stan bugfix: https://github.com/stan-dev/math/issues/1398
+  int can_do_bernoullilogitglm = K != 0 &&  // remove K!=0 after rstan includes this Stan bugfix: https://github.com/stan-dev/math/issues/1398
                                  link == 1 && clogit == 0 && has_offset == 0 && 
                                  prior_PD == 0 && dense_X == 1 && has_weights == 0 && t == 0;
   matrix[can_do_bernoullilogitglm ? NN : 0, can_do_bernoullilogitglm ? K + K_smooth : 0] XS;

--- a/src/stan_files/bernoulli.stan
+++ b/src/stan_files/bernoulli.stan
@@ -76,7 +76,9 @@ transformed data {
   int<lower=0> failures[clogit ? J : 0];
   int<lower=0> observations[clogit ? J : 0];
 
-  int can_do_bernoullilogitglm = link == 1 && clogit == 0 && has_offset == 0 && prior_PD == 0 && dense_X == 1 && has_weights == 0 && t == 0;
+  int can_do_bernoullilogitglm = K != 0 && // remove after rstan includes this Stan bugfix: https://github.com/stan-dev/math/issues/1398
+                                 link == 1 && clogit == 0 && has_offset == 0 && 
+                                 prior_PD == 0 && dense_X == 1 && has_weights == 0 && t == 0;
   matrix[can_do_bernoullilogitglm ? NN : 0, can_do_bernoullilogitglm ? K + K_smooth : 0] XS;
   int y[can_do_bernoullilogitglm ? NN : 0];
 

--- a/src/stan_files/continuous.stan
+++ b/src/stan_files/continuous.stan
@@ -74,9 +74,9 @@ transformed data {
                    prior_PD == 0 && dense_X && N > 2 && len_y >= (has_intercept + K + K_smooth);
   vector[can_do_OLS ? has_intercept + K + K_smooth : 0] OLS;
   matrix[can_do_OLS ? has_intercept + K + K_smooth : 0, can_do_OLS ? has_intercept + K + K_smooth : 0] XtX;
-  int can_do_normalidglm = can_do_OLS == 0 && family == 1 && link == 1 && SSfun == 0 && has_offset == 0 &&
-                           t == 0 && prior_PD == 0 && dense_X &&
-	                   len_y < (has_intercept + K + K_smooth);
+  int can_do_normalidglm = K != 0 && // remove after rstan includes this Stan bugfix: https://github.com/stan-dev/math/issues/1398
+                           can_do_OLS == 0 && family == 1 && link == 1 && SSfun == 0 && has_offset == 0 &&
+                           t == 0 && prior_PD == 0 && dense_X && len_y < (has_intercept + K + K_smooth);
   matrix[can_do_normalidglm ? N : 0, can_do_normalidglm ? K + K_smooth : 0] XS;
   real SSR = not_a_number();
   // defines hs, len_z_T, len_var_group, delta, is_continuous, pos

--- a/src/stan_files/continuous.stan
+++ b/src/stan_files/continuous.stan
@@ -74,9 +74,10 @@ transformed data {
                    prior_PD == 0 && dense_X && N > 2 && len_y >= (has_intercept + K + K_smooth);
   vector[can_do_OLS ? has_intercept + K + K_smooth : 0] OLS;
   matrix[can_do_OLS ? has_intercept + K + K_smooth : 0, can_do_OLS ? has_intercept + K + K_smooth : 0] XtX;
-  int can_do_normalidglm = K != 0 && // remove after rstan includes this Stan bugfix: https://github.com/stan-dev/math/issues/1398
-                           can_do_OLS == 0 && family == 1 && link == 1 && SSfun == 0 && has_offset == 0 &&
-                           t == 0 && prior_PD == 0 && dense_X && len_y < (has_intercept + K + K_smooth);
+  int can_do_normalidglm = K != 0 &&  // remove K!=0 after rstan includes this Stan bugfix: https://github.com/stan-dev/math/issues/1398 
+                           can_do_OLS == 0 && family == 1 && link == 1 && 
+                           SSfun == 0 && has_offset == 0 && dense_X && prior_PD == 0 && 
+                           t == 0 && len_y < (has_intercept + K + K_smooth);
   matrix[can_do_normalidglm ? N : 0, can_do_normalidglm ? K + K_smooth : 0] XS;
   real SSR = not_a_number();
   // defines hs, len_z_T, len_var_group, delta, is_continuous, pos

--- a/src/stan_files/count.stan
+++ b/src/stan_files/count.stan
@@ -26,7 +26,7 @@ transformed data{
   real poisson_max = pow(2.0, 30.0);
   int<lower=1> V[special_case ? t : 0, N] = make_V(N, special_case ? t : 0, v);
   
-  int can_do_countlogglm = K != 0 && // remove after rstan includes this Stan bugfix: https://github.com/stan-dev/math/issues/1398
+  int can_do_countlogglm = K != 0 &&  // remove K!=0 after rstan includes this Stan bugfix: https://github.com/stan-dev/math/issues/1398
                            link == 1 && prior_PD == 0 && 
                            dense_X == 1 && has_weights == 0 && t == 0; 
   matrix[can_do_countlogglm ? N : 0, can_do_countlogglm ? K + K_smooth : 0] XS;

--- a/src/stan_files/count.stan
+++ b/src/stan_files/count.stan
@@ -26,7 +26,9 @@ transformed data{
   real poisson_max = pow(2.0, 30.0);
   int<lower=1> V[special_case ? t : 0, N] = make_V(N, special_case ? t : 0, v);
   
-  int can_do_countlogglm = link == 1 && prior_PD == 0 && dense_X == 1 && has_weights == 0 && t == 0;
+  int can_do_countlogglm = K != 0 && // remove after rstan includes this Stan bugfix: https://github.com/stan-dev/math/issues/1398
+                           link == 1 && prior_PD == 0 && 
+                           dense_X == 1 && has_weights == 0 && t == 0; 
   matrix[can_do_countlogglm ? N : 0, can_do_countlogglm ? K + K_smooth : 0] XS;
   
   // defines hs, len_z_T, len_var_group, delta, pos


### PR DESCRIPTION
This PR adds the condition `K != 0` when checking whether to use Stan's compound glm functions. This fixes #396 but we can go back to allowing it for `K == 0` when https://github.com/stan-dev/math/issues/1398 is fixed in Stan math and included in rstan. 

I also included a commit that bumps the rstanarm version number up to 2.19.3. I think we should submit this to CRAN right away if possible with a comment apologizing for the quick turnaround. It should get through quickly given that it's the only change since they accepted 2.19.2. 