### PR TITLE
Fix #431: Make drop_redundant_dims safe for data.table

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -743,6 +743,9 @@ check_stanfit <- function(x) {
 #   otherwise if_missing is returned.
 #
 drop_redundant_dims <- function(data) {
+  if(inherits(data, "data.table")) {
+    return(data)
+  }
   drop_dim <- sapply(data, function(v) is.matrix(v) && NCOL(v) == 1)
   data[, drop_dim] <- lapply(data[, drop_dim, drop=FALSE], drop)
   return(data)


### PR DESCRIPTION
Modify `drop_redundant_dims` to avoid an error when data is a data.table, as reported in #431. This happens because `drop_redundant_dims` indexes into a data.frame using a vector of logicals, but data.table expects an unquoted name to be a column name. To fix this, my code skips the dimension-reduction step if data is a data.table.

This shouldn't cause problems with data.table: In general, dimension reduction like this isn't necessary for a data.table, because data.table makes it really difficult to add a matrix as a column. The only way to do this is to explicitly coerce an existing data.frame that has matrices as columns using `setDT()`, and that will warn the user against doing this (see https://github.com/Rdatatable/data.table/pull/3851). For any other case, data.table will automatically coerce matrices into columns. In other words, data.table does this dimension reduction automatically, so it can be safely skipped.