### PR TITLE
fix incorrect handling of contrasts in stan_glm

### DIFF
--- a/R/stan_glm.R
+++ b/R/stan_glm.R
@@ -236,6 +236,7 @@ stan_glm <-
   if (is.empty.model(mt))
     stop("No intercept or predictors specified.", call. = FALSE)
   X <- model.matrix(mt, mf, contrasts)
+  contrasts <- attr(X, "contrasts")
   weights <- validate_weights(as.vector(model.weights(mf)))
   offset <- validate_offset(as.vector(model.offset(mf)), y = Y)
   if (binom_y_prop(Y, family, weights)) {
@@ -277,7 +278,7 @@ stan_glm <-
   fit <- nlist(stanfit, algorithm, family, formula, data, offset, weights,
                x = X, y = Y, model = mf,  terms = mt, call, 
                na.action = attr(mf, "na.action"), 
-               contrasts = attr(X, "contrasts"), 
+               contrasts = contrasts, 
                stan_function = "stan_glm")
   
   out <- stanreg(fit)

--- a/tests/testthat/test_stan_glm.R
+++ b/tests/testthat/test_stan_glm.R
@@ -457,3 +457,12 @@ test_that("posterior_predict compatible with glms", {
   expect_linpred_equal(fit_igaus)
   
 })
+
+
+test_that("contrasts attribute isn't dropped", {
+  contrasts <- list(wool = "contr.sum", tension = "contr.sum")
+  fit <- stan_glm(breaks ~ wool * tension, data = warpbreaks,
+                 contrasts = contrasts, 
+                 chains = 1, refresh = 0)
+  expect_equal(fit$contrasts, contrasts)
+})


### PR DESCRIPTION
closes #444 
closes #445

@bgoodri This fixes an important bug reported by @rvlenth. It turns out the same problem was causing both #444 and #445.

The fix is to make sure `contrasts` info isn't accidentally dropped when subsetting the model matrix. 

This now gives correct results: 

```r
contrasts <- list(wool = "contr.sum", tension = "contr.sum")
fit <-  stan_glm(breaks ~ wool * tension, data = warpbreaks,
                 contrasts = contrasts, chains = 1, refresh = 0)
```

```
> fit$contrasts
$wool
[1] "contr.sum"

$tension
[1] "contr.sum"
```

```
> predict(fit, newdata = warpbreaks[1:3, ])
       1        2        3 
44.55111 44.55111 44.55111 
```

```
> model.matrix(fit)
   (Intercept) wool1 tension1 tension2 wool1:tension1 wool1:tension2
1            1     1        1        0              1              0
2            1     1        1        0              1              0
3            1     1        1        0              1              0
4            1     1        1        0              1              0
5            1     1        1        0              1              0
6            1     1        1        0              1              0
7            1     1        1        0              1              0
8            1     1        1        0              1              0
9            1     1        1        0              1              0
10           1     1        0        1              0              1
11           1     1        0        1              0              1
12           1     1        0        1              0              1
13           1     1        0        1              0              1
14           1     1        0        1              0              1
15           1     1        0        1              0              1
16           1     1        0        1              0              1
17           1     1        0        1              0              1
18           1     1        0        1              0              1
19           1     1       -1       -1             -1             -1
20           1     1       -1       -1             -1             -1
21           1     1       -1       -1             -1             -1
22           1     1       -1       -1             -1             -1
23           1     1       -1       -1             -1             -1
24           1     1       -1       -1             -1             -1
25           1     1       -1       -1             -1             -1
26           1     1       -1       -1             -1             -1
27           1     1       -1       -1             -1             -1
28           1    -1        1        0             -1              0
29           1    -1        1        0             -1              0
30           1    -1        1        0             -1              0
31           1    -1        1        0             -1              0
32           1    -1        1        0             -1              0
33           1    -1        1        0             -1              0
34           1    -1        1        0             -1              0
35           1    -1        1        0             -1              0
36           1    -1        1        0             -1              0
37           1    -1        0        1              0             -1
38           1    -1        0        1              0             -1
39           1    -1        0        1              0             -1
40           1    -1        0        1              0             -1
41           1    -1        0        1              0             -1
42           1    -1        0        1              0             -1
43           1    -1        0        1              0             -1
44           1    -1        0        1              0             -1
45           1    -1        0        1              0             -1
46           1    -1       -1       -1              1              1
47           1    -1       -1       -1              1              1
48           1    -1       -1       -1              1              1
49           1    -1       -1       -1              1              1
50           1    -1       -1       -1              1              1
51           1    -1       -1       -1              1              1
52           1    -1       -1       -1              1              1
53           1    -1       -1       -1              1              1
54           1    -1       -1       -1              1              1
attr(,"assign")
[1] 0 1 2 2 3 3
attr(,"contrasts")
attr(,"contrasts")$wool
[1] "contr.sum"

attr(,"contrasts")$tension
[1] "contr.sum"

```