### PR TITLE
uncomment roxygen lines from cleanup[.win]

### DIFF
--- a/cleanup
+++ b/cleanup
@@ -1,5 +1,5 @@
 #!/bin/sh -e
 
 # Note to Windows users: This is not actually platform specific.
-# "${R_HOME}/bin/R" --vanilla --slave -e 'roxygen2::roxygenize(clean = FALSE)'
+"${R_HOME}/bin/R" --vanilla --slave -e 'roxygen2::roxygenize(clean = FALSE)'
 exit $?

--- a/cleanup.win
+++ b/cleanup.win
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # Note to Windows users: This is not actually platform specific.
-# "${R_HOME}/bin/R" --vanilla --slave -e 'roxygen2::roxygenize(clean = FALSE)'
+"${R_HOME}/bin/R" --vanilla --slave -e 'roxygen2::roxygenize(clean = FALSE)'
 cp -r src/stan_files tests/testthat/stan_files
 cp -r inst/include tests/testthat/include
 exit $?


### PR DESCRIPTION
This is an alternative to #474 that adds roxygenize() to cleanup and cleanup.win instead of tracking manual pages. 