### PR TITLE
Allow 0-column newdata if positive number of rows

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -814,7 +814,9 @@ validate_newdata <- function(object, newdata = NULL, m = NULL) {
     stop("NAs are not allowed in 'newdata'.", call. = FALSE)
   }
   
-  newdata <- drop_redundant_dims(newdata)
+  if (ncol(newdata) > 0) {
+    newdata <- drop_redundant_dims(newdata)
+  }
   return(newdata)
 }
 


### PR DESCRIPTION
fixes #491

This PR avoids performing one of the checks on `newdata` that resulted in an error if `newdata` had 0 columns. Allowing 0-column `newdata` is useful for doing `posterior_predict()` for intercept only models, as pointed out in #491  by @davidkane9. With this change, the following now works: 

```r
fit <- stan_glm(mpg ~ 1, data = mtcars)
posterior_predict(fit, newdata = tibble::tibble(.rows = 1)) # generate predictions for 1 obs
posterior_predict(fit, newdata = tibble::tibble(.rows = 2)) # generate predictions for 2 obs
...
```