### PR TITLE
Add survival version to README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,16 @@ and
 [CRAN](https://cran.r-project.org/package=rstanarm/vignettes). 
 If installation fails, please let us know by [filing an issue](https://github.com/stan-dev/rstanarm/issues).
 
+#### Survival Analysis Version
+
+The `feature/survival` branch on GitHub contains a development version of **rstanarm** that includes survival analysis functionality (via the `stan_surv` modelling function). Until this functionality is available in the CRAN release of **rstanarm**, users who wish to use the survival analysis functionality can install a binary version of the survival branch of **rstanarm** from the Stan R packages repository with:
+
+```
+install.packages("rstanarm", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+```
+
+Note that this binary is static (i.e. it is not automatically updated) and is only hosted so that users can access the (experimental) survival analysis functionality without needing to go through the time consuming (and sometimes painful) task of installing the development version of **rstanarm** from source.
+
 ### Contributing 
 
 If you are interested in contributing to the development of **rstanarm** please 


### PR DESCRIPTION
Adds README instructions for how to install the binary for the development version with `stan_surv` functionality. As requested in this forum post: https://discourse.mc-stan.org/t/rstanarm-cran-vs-development-version-installation-issues/14399/45