### PR TITLE
Reduce recommended cores for makeflags during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ Once **rstan** is successfully installed, you can install **rstanarm** from
 GitHub using the **remotes** package by executing the following in R:
 
 ```r
-Sys.setenv(MAKEFLAGS = "-j4") # change 4 to however many cores you can/want to use to parallelize install 
+# Change 2 to however many cores you can/want to use to parallelize install
+# If you experience crashes or run out RAM during installation, try changing this to 1
+Sys.setenv(MAKEFLAGS = "-j2")
 Sys.setenv("R_REMOTES_NO_ERRORS_FROM_WARNINGS" = "true")
 remotes::install_github("stan-dev/rstanarm", INSTALL_opts = "--no-multiarch", force = TRUE)
 ```


### PR DESCRIPTION
As experienced over in #512, users can run out of RAM when installing `rstanarm` from source with the recommended `-j4`. This drops the recommended number to 2 and adds a warning