### PR TITLE
don't recommend QR if not enough predictors

### DIFF
--- a/R/stan_betareg.fit.R
+++ b/R/stan_betareg.fit.R
@@ -352,8 +352,9 @@ stan_betareg.fit <-
     } else { # algorithm either "meanfield" or "fullrank"
       stanfit <- rstan::vb(stanfit, pars = pars, data = standata,
                            algorithm = algorithm, init = 0.001, ...)
-      if (!QR) 
+      if (!QR && standata$K > 1) {
         recommend_QR_for_vb()
+      }
     }
     check <- check_stanfit(stanfit)
     if (!isTRUE(check)) return(standata)

--- a/R/stan_glm.fit.R
+++ b/R/stan_glm.fit.R
@@ -679,8 +679,9 @@ stan_glm.fit <-
       vb_args$algorithm <- algorithm
       vb_args$importance_resampling <- importance_resampling
       stanfit <- do.call(vb, args = vb_args)
-      if (!QR) 
+      if (!QR && standata$K > 1) {
         recommend_QR_for_vb()
+      }
     }
     check <- try(check_stanfit(stanfit))
     if (!isTRUE(check)) return(standata)

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -496,10 +496,3 @@ test_that("validate_newdata works", {
   expect_error(validate_newdata(fit, newdata = newd), "NAs are not allowed")
 })
 
-
-test_that("recommend_QR_for_vb produces the right message", {
-  expect_message(
-    rstanarm:::recommend_QR_for_vb(),
-    "Setting 'QR' to TRUE can often be helpful when using one of the variational inference algorithms"
-  )
-})

--- a/tests/testthat/test_stan_betareg.R
+++ b/tests/testthat/test_stan_betareg.R
@@ -106,6 +106,32 @@ if (.Platform$OS.type != "windows" && require(betareg)) {
     expect_equal(val, ans, tol = 0.1)
   })
   
+  test_that("QR recommended if VB and at least 2 predictors", {
+    expect_message(
+      stan_betareg(y ~ x + z, data = dat, 
+                   link = "logit", algorithm = "meanfield",
+                   prior = NULL, prior_intercept = NULL, 
+                   prior_phi = NULL, refresh = 0),
+      "Setting 'QR' to TRUE can often be helpful when using one of the variational inference algorithms"
+    )
+    # no message if QR already specified
+    expect_message(
+      stan_betareg(y ~ x + z, data = dat, QR = TRUE,
+                   link = "logit", algorithm = "meanfield",
+                   prior = NULL, prior_intercept = NULL, 
+                   prior_phi = NULL, refresh = 0),
+      NA
+    )
+    # no message if only 1 predictor
+    expect_message(
+      stan_betareg(y ~ x, data = dat,
+                   link = "logit", algorithm = "meanfield",
+                   prior = NULL, prior_intercept = NULL, 
+                   prior_phi = NULL, refresh = 0),
+      NA
+    )
+  })
+  
   test_that("stan_betareg ok when modeling x and z (link.phi = 'log')", {
     N <- 200
     dat <- data.frame(x = rnorm(N, 2, 1), z = rnorm(N, 2, 1))

--- a/tests/testthat/test_stan_glm.R
+++ b/tests/testthat/test_stan_glm.R
@@ -447,3 +447,28 @@ test_that("contrasts attribute isn't dropped", {
                  chains = 1, refresh = 0))
   expect_equal(fit$contrasts, contrasts)
 })
+
+
+test_that("QR recommended if VB and at least 2 predictors", {
+  expect_message(
+    SW(stan_glm(mpg ~ wt + cyl, data = mtcars, algorithm = "meanfield", refresh = 0)),
+    "Setting 'QR' to TRUE can often be helpful when using one of the variational inference algorithms"
+  )
+  # no message if QR already specified
+  expect_message(
+    SW(stan_glm(mpg ~ wt + cyl, data = mtcars, algorithm = "meanfield", refresh = 0, QR = TRUE)),
+    NA
+  )
+  # no message if only 1 predictor
+  expect_message(
+    SW(stan_glm(mpg ~ wt, data = mtcars, algorithm = "meanfield", refresh = 0)),
+    NA
+  )
+})
+
+test_that("QR errors if only 1 predictor", {
+  expect_error(
+    stan_glm(mpg ~ wt, data = mtcars, QR = TRUE),
+    "can only be specified when there are multiple predictors"
+  )
+})


### PR DESCRIPTION
fixes #469

Only recommends QR=TRUE for variational inference if there are at least 2 predictors. Previously we were recommending it also for 1 predictor but it would then error if the user tried that. 