### PR TITLE
include 'subset' info in print output

### DIFF
--- a/R/print-and-summary.R
+++ b/R/print-and-summary.R
@@ -463,13 +463,13 @@ print.summary.stanreg <-
     if (!is.null(atts$npreds)) {
       cat("\n predictors:  ", atts$npreds)
     }
+    if (!is.null(atts$call$subset)) {
+      cat("\n subset:      ", deparse(atts$call$subset))
+    }
     if (!is.null(atts$ngrps)) {
       cat("\n groups:      ", paste0(names(atts$ngrps), " (", 
                                      unname(atts$ngrps), ")", 
                                      collapse = ", "))
-    }
-    if (!is.null(atts$call$subset)) {
-      cat("\n subset:      ", deparse(atts$call$subset))
     }
     
     cat("\n\nEstimates:\n")

--- a/R/print-and-summary.R
+++ b/R/print-and-summary.R
@@ -77,6 +77,9 @@ print.stanreg <- function(x, digits = 1, detail = TRUE, ...) {
                c("stan_glm", "stan_glm.nb", "stan_lm", "stan_aov"))) {
       cat("\n predictors:  ", length(coef(x)))
     }
+    if (!is.null(x$call$subset)) {
+      cat("\n subset:      ", deparse(x$call$subset))
+    }
   
     cat("\n------\n")
   }
@@ -464,6 +467,9 @@ print.summary.stanreg <-
       cat("\n groups:      ", paste0(names(atts$ngrps), " (", 
                                      unname(atts$ngrps), ")", 
                                      collapse = ", "))
+    }
+    if (!is.null(atts$call$subset)) {
+      cat("\n subset:      ", deparse(atts$call$subset))
     }
     
     cat("\n\nEstimates:\n")

--- a/tests/testthat/test_methods.R
+++ b/tests/testthat/test_methods.R
@@ -627,7 +627,21 @@ test_that("print and summary methods ok for mcmc and vb", {
   expect_s3_class(s, "summary.stanreg")
   expect_output(print(s), "stan_betareg")
   expect_identical(attr(s, "algorithm"), "sampling")
+})
+
+test_that("print and summary include subset information", {
+  SW(fit <- stan_glm(mpg ~ wt, data = mtcars, subset = cyl == 4, iter = 5, chains = 1, refresh = 0))
+  expect_output(print(fit), "subset:       cyl == 4")
+  expect_output(print(summary(fit)), "subset:       cyl == 4")
   
+  SW(fit <- stan_glm(mpg ~ wt, data = mtcars, subset = rep(TRUE, 32), iter = 5, chains = 1, refresh = 0))
+  expect_output(print(fit), "subset:       rep(TRUE, 32)", fixed = TRUE)
+  expect_output(print(summary(fit)), "subset:       rep(TRUE, 32)", fixed = TRUE)
+  
+  sub <- mtcars$cyl == 4
+  SW(fit <- stan_glm(mpg ~ wt, data = mtcars, subset = sub, iter = 5, chains = 1, refresh = 0))
+  expect_output(print(fit), "subset:       sub", fixed = TRUE)
+  expect_output(print(summary(fit)), "subset:       sub", fixed = TRUE)
 })
 
 test_that("print and summary methods ok for optimization", {


### PR DESCRIPTION
fixes #411

If `subset` is specified the print and summary output now include it. A few examples: 

```
> stan_glm(mpg ~ wt + cyl, data = mtcars, subset = rep(TRUE, 32))

stan_glm
 family:       gaussian [identity]
 formula:      mpg ~ wt + cyl
 observations: 32
 predictors:   3
 subset:       rep(TRUE, 32)
...
```
```
> stan_glm(mpg ~ wt + am, data = mtcars, subset = cyl == 4)

stan_glm
 family:       gaussian [identity]
 formula:      mpg ~ wt + am
 observations: 11
 predictors:   3
 subset:       cyl == 4
...
```