### PR TITLE
error earlier if outcome is character

### DIFF
--- a/R/stan_glm.fit.R
+++ b/R/stan_glm.fit.R
@@ -66,7 +66,7 @@ stan_glm.fit <-
     prior_aux <- tmp[["prior_aux"]]
     prior_ops <- NULL
   }
-  
+
   algorithm <- match.arg(algorithm)
   family <- validate_family(family)
   supported_families <- c("binomial", "gaussian", "Gamma", "inverse.gaussian",
@@ -788,6 +788,10 @@ stan_family_number <- function(famname) {
 # @return y (possibly slightly modified) unless an error is thrown
 #
 validate_glm_outcome_support <- function(y, family) {
+  if (is.character(y)) {
+    stop("Outcome variable can't be type 'character'.", call. = FALSE)
+  }
+  
   if (is.null(y)) {
     return(y)
   }

--- a/tests/testthat/test_stan_glmer.R
+++ b/tests/testthat/test_stan_glmer.R
@@ -117,6 +117,17 @@ test_that("stan_lmer returns an error when 'family' specified", {
   )
 })
 
+test_that("error if y is character", {
+  expect_error(
+    stan_lmer(as.character(mpg) ~ wt + (1|cyl),  data = mtcars),
+    "Outcome variable can't be type 'character'"
+  )
+  expect_error(
+    stan_glmer.nb(as.character(mpg) ~ wt + (1|cyl),  data = mtcars),
+    "Outcome variable can't be type 'character'"
+  )
+})
+
 
 context("stan_gamm4")
 test_that("stan_gamm4 returns stanreg object", {

--- a/tests/testthat/test_stan_jm.R
+++ b/tests/testthat/test_stan_jm.R
@@ -80,6 +80,13 @@ test_that("formula argument works", {
   expect_equal(jm_offset$glmod$Long1$has_offset, 1)
 })
 
+test_that("error if outcome is character", {
+  expect_error(
+    update(jm1, formulaLong. = as.character(logBili) ~ year + (year | id)), 
+    "Outcome variable can't be type 'character'"
+  )
+})
+
 test_that("data argument works", {
   SW(fit <- update(jm1, dataLong = list(pbcLong)))
   expect_identical(as.matrix(jm1), 

--- a/tests/testthat/test_stan_mvmer.R
+++ b/tests/testthat/test_stan_mvmer.R
@@ -48,11 +48,11 @@ pbcLong$xgamm <- as.numeric(pbcLong$logBili)
 
 # univariate GLM
 fm1 <- logBili ~ year + (year | id)
-o<-SW(m1 <- stan_mvmer(fm1, pbcLong, iter = 100, chains = 1, seed = SEED, refresh = 0))
+o<-SW(m1 <- stan_mvmer(fm1, pbcLong, iter = 5, chains = 1, seed = SEED, refresh = 0))
 
 # multivariate GLM
 fm2 <- list(logBili ~ year + (year | id), albumin ~ year + (year | id))
-o<-SW(m2 <- stan_mvmer(fm2, pbcLong, iter = 100, chains = 1, seed = SEED, refresh = 0))
+o<-SW(m2 <- stan_mvmer(fm2, pbcLong, iter = 5, chains = 1, seed = SEED, refresh = 0))
 
 #----  Tests for stan_mvmer arguments
 
@@ -60,6 +60,14 @@ test_that("formula argument works", {
   SW(m991 <- update(m1, formula. = list(fm1)))
   expect_identical(as.matrix(m1), as.matrix(m991)) # fm as list
 })
+
+test_that("error if outcome is character", {
+  expect_error(
+    update(m1, formula. = as.character(logBili) ~ year + (year | id)), 
+    "Outcome variable can't be type 'character'"
+  )
+})
+
 
 test_that("data argument works", {
   SW(m991 <- update(m1, data = list(pbcLong)))


### PR DESCRIPTION
fixes #341

This affects models using `stan_glm.fit` as well as `stan_jm` and `stan_mvmer`, which use the same internal `validate_glm_outcome_support` that `stan_glm.fit` does. 

Previous error message: 

```
f1 <- stan_lmer(formula = as.character(logBili) ~ 1 + (1 | id), 
                 data = pbcLong, 
                 chains = 1)

Error in new_CppObject_xp(fields$.module, fields$.pointer, ...) : 
  Exception: variable does not exist; processing stage=data initialization; variable name=y; base type=vector_d  (in 'model_continuous' at line 32)

In addition: Warning message:
In FUN(X[[i]], ...) : data with name y is not numeric and not used
failed to create the sampler; sampling not done
Error in check_stanfit(stanfit) : 
  Invalid stanfit object produced please report bug
Error in dimnamesGets(x, value) : 
  invalid dimnames given for “dgCMatrix” object
```

New error message: 

```
f1 <- stan_lmer(formula = as.character(logBili) ~ 1 + (1 | id), 
                 data = pbcLong, 
                 chains = 1)

Error: Outcome variable can't be type 'character'.
```