### PR TITLE
stan_gamm4: error if no smooth terms

### DIFF
--- a/R/stan_gamm4.R
+++ b/R/stan_gamm4.R
@@ -142,6 +142,10 @@ stan_gamm4 <-
   data <- validate_data(data, if_missing = list())
   family <- validate_family(family)
   
+  if (length(mgcv::interpret.gam(formula)$smooth.spec) == 0) {
+    stop("Formula must have at least one smooth term to use stan_gamm4.", call. = FALSE)
+  }
+  
   if (!is.null(random)) {
     fake.formula <- as.character(mgcv::interpret.gam(formula)$fake.formula)
     form <- paste(fake.formula[2], fake.formula[1], fake.formula[3],

--- a/tests/testthat/test_stan_glmer.R
+++ b/tests/testthat/test_stan_glmer.R
@@ -160,6 +160,18 @@ test_that("stan_gamm4 doesn't error when bs='cc", {
   expect_stanreg(fit3)
 })
 
+test_that("stan_gamm4 errors if no smooth terms in formula", {
+  dat <- data.frame(
+    y = rnorm(100), 
+    x = rnorm(100), 
+    id = gl(5, 20)
+  )
+  expect_error(
+    stan_gamm4(y ~ x, random = ~(1 | id), data = dat),
+    "Formula must have at least one smooth term to use stan_gamm4"
+  )
+})
+
 
 test_that("loo/waic for stan_glmer works", {
   ll_fun <- rstanarm:::ll_fun


### PR DESCRIPTION
fixes #288

Throw an error if no smooth terms instead of letting `mgcv::jagam` throw some jibberish error message. 