### PR TITLE
Improve error msg when incorrect newdata argument is passed to stan_surv/stan_jm

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -195,9 +195,12 @@ used.variational <- function(x) {
 # @param x A stanreg object.
 is.mer <- function(x) {
   stopifnot(is.stanreg(x))
+  check0 <- is.stansurv(x) && x$has_bars
   check1 <- inherits(x, "lmerMod")
   check2 <- !is.null(x$glmod)
-  if (check1 && !check2) {
+  if (check0) {
+    return(TRUE)
+  } else if (check1 && !check2) {
     stop("Bug found. 'x' has class 'lmerMod' but no 'glmod' component.")
   } else if (!check1 && check2) {
     stop("Bug found. 'x' has 'glmod' component but not class 'lmerMod'.")

--- a/R/posterior_survfit.R
+++ b/R/posterior_survfit.R
@@ -392,6 +392,15 @@ posterior_survfit.stansurv <- function(object,
   
   dots <- list(...)
   
+  if ("newdataEvent" %in% names(dots))
+    stop("The argument 'newdataEvent' should not be specified when ",
+         "predicting for stan_surv models. Perhaps you meant to specify ",
+         "'newdata' instead of 'newdataEvent'.")
+  
+  if ("newdataLong" %in% names(dots))
+    stop("The argument 'newdataLong' should not be specified when ",
+         "predicting for stan_surv models.")
+    
   newdata <- validate_newdata(object, newdata = newdata)
   has_newdata <- not.null(newdata)
   
@@ -585,6 +594,11 @@ posterior_survfit.stanjm <- function(object,
     ids <- NULL
   
   dots <- list(...)
+  
+  if ("newdata" %in% names(dots))
+    stop("The argument 'newdata' should not be specified when predicting ",
+         "for stan_jm models. You should specify 'newdataLong' and ",
+         "'newdataEvent' instead of 'newdata'.")
   
   # Temporarily only allow survprob for stan_jm until refactoring is done
   if (!type == "surv")


### PR DESCRIPTION
Fixes #458 on the `feature/survival` branch. So that passing `newdataEvent` or `newdataLong` to stan_surv post-estimation functions throws an error, and passing `newdataEvent` to stan_jm post-estimation functions throws an error.

Also ensures that a `stan_surv` model with group specific parameters is returned as TRUE for `is.mer()`. Can't remember exactly what that fix was for, but I'm guessing to ensure some post-estimation extraction functions related to random effects work (maybe `ranef()` or something similar).