### PR TITLE
wells dataset wrong variable name

### DIFF
--- a/R/doc-datasets.R
+++ b/R/doc-datasets.R
@@ -162,7 +162,7 @@
 #' \item \code{arsenic} Arsenic level in respondent's well
 #' \item \code{dist} Distance (meters) from the respondent's house to the
 #' nearest well with safe drinking water.
-#' \item \code{association} Indicator for member(s) of household participate
+#' \item \code{assoc} Indicator for member(s) of household participate
 #' in community organizations
 #' \item \code{educ} Years of education (head of household)
 #' }


### PR DESCRIPTION
While lecturing this week on binomial regression I was showcasing the `wells` dataset (Gelman & Hill, 2007) and found an incosistency.
In the help pane the variable was named as `association` but it is only `assoc`.

```r
r$> names(wells)
[1] "switch"  "arsenic" "dist"    "assoc"   "educ"
```