### PR TITLE
remove 'px' as CRAN requested

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -71,4 +71,4 @@ UseLTO: true
 NeedsCompilation: yes
 URL: https://mc-stan.org/rstanarm/, https://discourse.mc-stan.org
 BugReports: https://github.com/stan-dev/rstanarm/issues
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/R/doc-rstanarm-package.R
+++ b/R/doc-rstanarm-package.R
@@ -39,7 +39,7 @@
 #'
 #' @description
 #' \if{html}{
-#'    \figure{stanlogo.png}{options: width="50px" alt="http://mc-stan.org/about/logo/"}
+#'    \figure{stanlogo.png}{options: width="50" alt="http://mc-stan.org/about/logo/"}
 #'    \emph{Stan Development Team}
 #' }
 #'

--- a/R/stan_betareg.R
+++ b/R/stan_betareg.R
@@ -17,7 +17,7 @@
 
 #' Bayesian beta regression models via Stan
 #'
-#' \if{html}{\figure{stanlogo.png}{options: width="25px" alt="http://mc-stan.org/about/logo/"}}
+#' \if{html}{\figure{stanlogo.png}{options: width="25" alt="http://mc-stan.org/about/logo/"}}
 #' Beta regression modeling with optional prior distributions for the 
 #' coefficients, intercept, and auxiliary parameter \code{phi} (if applicable).
 #'

--- a/R/stan_biglm.R
+++ b/R/stan_biglm.R
@@ -17,7 +17,7 @@
 
 #' Bayesian regularized linear but big models via Stan
 #' 
-#' \if{html}{\figure{stanlogo.png}{options: width="25px" alt="http://mc-stan.org/about/logo/"}}
+#' \if{html}{\figure{stanlogo.png}{options: width="25" alt="http://mc-stan.org/about/logo/"}}
 #' This is the same model as with \code{\link{stan_lm}} but it utilizes the
 #' output from \code{\link[biglm]{biglm}} in the \pkg{biglm} package in order to
 #' proceed when the data is too large to fit in memory.

--- a/R/stan_clogit.R
+++ b/R/stan_clogit.R
@@ -17,7 +17,7 @@
 
 #' Conditional logistic (clogit) regression models via Stan
 #'
-#' \if{html}{\figure{stanlogo.png}{options: width="25px" alt="http://mc-stan.org/about/logo/"}}
+#' \if{html}{\figure{stanlogo.png}{options: width="25" alt="http://mc-stan.org/about/logo/"}}
 #' A model for case-control studies with optional prior distributions for the
 #' coefficients, intercept, and auxiliary parameters.
 #'

--- a/R/stan_gamm4.R
+++ b/R/stan_gamm4.R
@@ -19,7 +19,7 @@
 #' Bayesian generalized linear additive models with optional group-specific
 #' terms via Stan
 #' 
-#' \if{html}{\figure{stanlogo.png}{options: width="25px" alt="http://mc-stan.org/about/logo/"}}
+#' \if{html}{\figure{stanlogo.png}{options: width="25" alt="http://mc-stan.org/about/logo/"}}
 #' Bayesian inference for GAMMs with flexible priors.
 #' 
 #' @export

--- a/R/stan_glm.R
+++ b/R/stan_glm.R
@@ -17,7 +17,7 @@
 
 #' Bayesian generalized linear models via Stan
 #'
-#' \if{html}{\figure{stanlogo.png}{options: width="25px" alt="http://mc-stan.org/about/logo/"}}
+#' \if{html}{\figure{stanlogo.png}{options: width="25" alt="http://mc-stan.org/about/logo/"}}
 #' Generalized linear modeling with optional prior distributions for the
 #' coefficients, intercept, and auxiliary parameters.
 #'

--- a/R/stan_glmer.R
+++ b/R/stan_glmer.R
@@ -17,7 +17,7 @@
 
 #' Bayesian generalized linear models with group-specific terms via Stan
 #' 
-#' \if{html}{\figure{stanlogo.png}{options: width="25px" alt="http://mc-stan.org/about/logo/"}}
+#' \if{html}{\figure{stanlogo.png}{options: width="25" alt="http://mc-stan.org/about/logo/"}}
 #' Bayesian inference for GLMs with group-specific coefficients that have 
 #' unknown covariance matrices with flexible priors.
 #' 

--- a/R/stan_jm.R
+++ b/R/stan_jm.R
@@ -18,7 +18,7 @@
 
 #' Bayesian joint longitudinal and time-to-event models via Stan
 #' 
-#' \if{html}{\figure{stanlogo.png}{options: width="25px" alt="http://mc-stan.org/about/logo/"}}
+#' \if{html}{\figure{stanlogo.png}{options: width="25" alt="http://mc-stan.org/about/logo/"}}
 #' Fits a shared parameter joint model for longitudinal and time-to-event 
 #' (e.g. survival) data under a Bayesian framework using Stan.
 #' 

--- a/R/stan_lm.R
+++ b/R/stan_lm.R
@@ -17,7 +17,7 @@
 
 #' Bayesian regularized linear models via Stan
 #' 
-#' \if{html}{\figure{stanlogo.png}{options: width="25px" alt="http://mc-stan.org/about/logo/"}}
+#' \if{html}{\figure{stanlogo.png}{options: width="25" alt="http://mc-stan.org/about/logo/"}}
 #' Bayesian inference for linear modeling with regularizing priors on the model
 #' parameters that are driven by prior beliefs about \eqn{R^2}, the proportion
 #' of variance in the outcome attributable to the predictors. See

--- a/R/stan_mvmer.R
+++ b/R/stan_mvmer.R
@@ -19,7 +19,7 @@
 #' Bayesian multivariate generalized linear models with correlated 
 #' group-specific terms via Stan
 #' 
-#' \if{html}{\figure{stanlogo.png}{options: width="25px" alt="http://mc-stan.org/about/logo/"}}
+#' \if{html}{\figure{stanlogo.png}{options: width="25" alt="http://mc-stan.org/about/logo/"}}
 #' Bayesian inference for multivariate GLMs with group-specific coefficients 
 #' that are assumed to be correlated across the GLM submodels.
 #' 

--- a/R/stan_nlmer.R
+++ b/R/stan_nlmer.R
@@ -17,7 +17,7 @@
 
 #' Bayesian nonlinear models with group-specific terms via Stan
 #' 
-#' \if{html}{\figure{stanlogo.png}{options: width="25px" alt="http://mc-stan.org/about/logo/"}}
+#' \if{html}{\figure{stanlogo.png}{options: width="25" alt="http://mc-stan.org/about/logo/"}}
 #' Bayesian inference for NLMMs with group-specific coefficients that have 
 #' unknown covariance matrices with flexible priors.
 #'

--- a/R/stan_polr.R
+++ b/R/stan_polr.R
@@ -18,7 +18,7 @@
 
 #' Bayesian ordinal regression models via Stan
 #'
-#' \if{html}{\figure{stanlogo.png}{options: width="25px" alt="http://mc-stan.org/about/logo/"}}
+#' \if{html}{\figure{stanlogo.png}{options: width="25" alt="http://mc-stan.org/about/logo/"}}
 #' Bayesian inference for ordinal (or binary) regression models under a
 #' proportional odds assumption.
 #'


### PR DESCRIPTION
@bgoodri This removes all the `'px'` uses with the Stan logo that CRAN complained about. 