### PR TITLE
Use | instead of || for or condition

### DIFF
--- a/R/stan_surv.R
+++ b/R/stan_surv.R
@@ -515,7 +515,7 @@ stan_surv <- function(formula,
   if (any(is.na(status)))
     stop2("Invalid status indicator in Surv object.")
   
-  if (any(status < 0 || status > 3))
+  if (any(status < 0 | status > 3))
     stop2("Invalid status indicator in Surv object.")
 
   # delayed entry indicator for each row of data
@@ -1793,7 +1793,7 @@ parse_formula_and_data <- function(formula, data) {
   if (any(is.na(status)))
     stop2("Invalid status indicator in Surv object.")
   
-  if (any(status < 0 || status > 3))
+  if (any(status < 0 | status > 3))
     stop2("Invalid status indicator in Surv object.")
   
   # deal with tve(x, ...)


### PR DESCRIPTION
Changes introduced in R>=4.3 mean that the `||` operator returns an error when it is used to evaluate an or condition for a length > 1 vector. The fix here is to instead use the vectorised form, `|` (which probably should have been used in the first place...).

Fixes #593.