### PR TITLE
Update more deprecated syntax

### DIFF
--- a/dev-notes/rstanarm_dev_notes.md
+++ b/dev-notes/rstanarm_dev_notes.md
@@ -70,7 +70,7 @@ Because we center the covariates when there is an intercept, you have to separat
 ```
 ...
 generated quantities {
-  real alpha[has_intercept];
+  array[has_intercept] real alpha;
   if (has_intercept) {
     alpha[1] = gamma[1] - dot_product(beta, xbar)
   }

--- a/src/stan_files/functions/SSfunctions.stan
+++ b/src/stan_files/functions/SSfunctions.stan
@@ -1,14 +1,3 @@
-vector SS_asymp(vector input, matrix Phi_);
-vector SS_asympOff(vector input, matrix Phi_);
-vector SS_asympOrig(vector input, matrix Phi_);
-vector SS_biexp(vector input, matrix Phi_);
-vector SS_fol(vector Dose, vector input, matrix Phi_);
-vector SS_fpl(vector input, matrix Phi_);
-vector SS_gompertz(vector x, matrix Phi_);
-vector SS_logis(vector input, matrix Phi_);
-vector SS_micmen(vector input, matrix Phi_);
-vector SS_weibull(vector x, matrix Phi_);
-
 /* These functions (without the underscores) are all documented in R
    See also Appendix C of Pinheiro and Bates
 https://books.google.com/books?id=3TVDAAAAQBAJ&lpg=PR3&dq=Pinheiro%20and%20Bates&pg=PA511#v=onepage&q&f=false

--- a/src/stan_files/functions/bernoulli_likelihoods.stan
+++ b/src/stan_files/functions/bernoulli_likelihoods.stan
@@ -82,7 +82,6 @@
    * @param eta_j Vector of linear predictions in the j-th group
    * @return A scalar that normalizes the probabilities on the log-scale
    */
-  real log_clogit_denom(int N_j, int D_j, vector eta_j);
   real log_clogit_denom(int N_j, int D_j, vector eta_j) {
     if (D_j == 1 && N_j == rows(eta_j)) return log_sum_exp(eta_j);
     if (D_j == 0) return 0;

--- a/src/stan_files/lm.stan
+++ b/src/stan_files/lm.stan
@@ -103,8 +103,14 @@ model {
   if (prior_dist == 1) {
     if (K > 1) 
       target += beta_lpdf(R2 | half_K, eta);
-    else 
-      target += beta_lpdf(square(R2) | half_K, eta) + sum(log(fabs(R2)));
+    else {
+      // TODO(Andrew) remove once vectorised abs available in rstan
+      array[J] real R2_abs;
+      for (j in 1:J) {
+        R2_abs[j] = abs(R2[j]);
+      }
+      target += beta_lpdf(square(R2) | half_K, eta) + sum(log(R2_abs));
+    }
   }
   // implicit: log_omega is uniform over the real line for all j
 }

--- a/src/stan_files/polr.stan
+++ b/src/stan_files/polr.stan
@@ -14,15 +14,15 @@ functions {
     // links in MASS::polr() are in a different order than binomial() 
     // logistic, probit, loglog, cloglog, cauchit
     if (link == 1) 
-      return (inv_logit(x));
+      return exp(log_inv_logit(x));
     else if (link == 2) 
-      return (Phi(x));
+      return exp(std_normal_lcdf(x|));
     else if (link == 3) 
-      return (gumbel_cdf(x, 0, 1));
+      return exp(gumbel_lcdf(x | 0, 1));
     else if (link == 4) 
-      return (inv_cloglog(x));
+      return inv_cloglog(x);
     else if (link == 5) 
-      return (cauchy_cdf(x, 0, 1));
+      return exp(cauchy_lcdf(x | 0, 1));
     else 
       reject("Invalid link");
     return x; // never reached


### PR DESCRIPTION
There are still some pieces of deprecated syntax in the rstanarm Stan models which will cause failures under 2.33:

- Forward declarations of Stan functions
- `fabs` deprecated in favour of `abs`
- `_cdf()` functions without `|` notation
  - Bug in 2.26 parser does not accept `cdf` functions *with* the `|` notation, so I've changed these to use the respective `_lcdf` function for compatibility with both 