### PR TITLE
avoid error for 1-D unit_vector

### DIFF
--- a/src/stan_files/lm.stan
+++ b/src/stan_files/lm.stan
@@ -55,7 +55,8 @@ transformed data {
 }
 parameters {
   // must not call with init="0"
-  array[K > 1 ? J : 0] unit_vector[K] u; // primitives for coefficients
+  // https://github.com/stan-dev/rstanarm/issues/603#issuecomment-1785928224
+  array[K > 1 ? J : 0] unit_vector[K > 1 ? K : 2] u; // primitives for coefficients
   array[J * has_intercept] real z_alpha; // primitives for intercepts
   array[J] real<lower=(K > 1 ? 0 : -1), upper=1> R2; // proportions of variance explained
   vector[J * (1 - prior_PD)] log_omega; // under/overfitting factors

--- a/src/stan_files/polr.stan
+++ b/src/stan_files/polr.stan
@@ -175,7 +175,9 @@ transformed data {
 }
 parameters {
   simplex[J] pi;
-  array[K > 1] unit_vector[K] u;
+  // avoid error by making unit_vector have 2 elements when K <= 1
+  // https://github.com/stan-dev/rstanarm/issues/603#issuecomment-1785928224
+  array[K > 1] unit_vector[K > 1 ? K : 2] u; 
   real<lower=(K > 1 ? 0 : -1), upper=1> R2;
   array[is_skewed] real<lower=0> alpha;
 }

--- a/tests/testthat/test_stan_lm.R
+++ b/tests/testthat/test_stan_lm.R
@@ -119,6 +119,13 @@ test_that("stan_lm doesn't break with vb algorithms", {
   expect_stanreg(fit2)
 })
 
+test_that("stan_lm works with 1 predictor", {
+  SW(fit <- stan_lm(mpg ~ wt, data = mtcars,
+                    prior = R2(0.5, "mean"), refresh = 0, 
+                    seed = SEED))
+  expect_stanreg(fit)
+})
+
 test_that("stan_lm throws error if only intercept", {
   expect_error(stan_lm(mpg ~ 1, data = mtcars, prior = R2(location = 0.75)),
                regexp = "not suitable for estimating a mean")

--- a/tests/testthat/test_stan_polr.R
+++ b/tests/testthat/test_stan_polr.R
@@ -56,6 +56,11 @@ test_that("stan_polr runs for esoph example", {
   expect_stanreg(fit2vb)
 })
 
+test_that("stan_polr runs with 1 predictor", {
+  esoph$x1 <- rnorm(nrow(esoph))
+  expect_stanreg(stan_polr(tobgp ~ x1, data = esoph, prior = R2(0.5, "mean")))
+})
+
 test_that("stan_polr throws error if formula excludes intercept", {
   expect_error(stan_polr(tobgp ~ 0 + agegp + alcgp, data = esoph, 
                          method = "loglog", prior = R2(0.4, "median")), 


### PR DESCRIPTION
fixes #603

The unit_vector isn't actually used anywhere in the situation when it errors (when K isn't >1) so we just make it size 2 in that case to avoid Stan's error for 1-D unit vectors. 

I also added tests for stan_lm and stan_polr to check that they now run with 1 predictor. 

