### PR TITLE
Fix mistaken ')' alignment in output test

### DIFF
--- a/tests/testthat/test_methods.R
+++ b/tests/testthat/test_methods.R
@@ -594,7 +594,8 @@ test_that("print and summary methods ok for mcmc and vb", {
   expect_output(print(s), "stan_glmer")
   expect_output(
     print(s), 
-    paste(rstanarm:::posterior_sample_size(example_model)), "(posterior sample size)"
+    paste(rstanarm:::posterior_sample_size(example_model), "(posterior sample size)"),
+    fixed = TRUE
   )
   expect_identical(attr(s, "algorithm"), "sampling")
   expect_identical(colnames(s), colnames(d))


### PR DESCRIPTION
I'm not sure exactly how this test is passing now, but AFAICT the intent is to match `{n} (posterior sample size)` where `n` is the result of the `posterior_sample_size()` call.

Something like, `...` is swallowing the `"(...)"` string and the test passes because `500` is matched.